### PR TITLE
feat(learning): 학습 도메인 엔티티 및 DB 데이블 매핑 구현

### DIFF
--- a/src/main/java/kr/co/mapspring/learning/entity/Badge.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/Badge.java
@@ -1,0 +1,40 @@
+package kr.co.mapspring.learning.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "badge")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Badge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "badge_id", nullable = false, updatable = false)
+    private Long badgeId;
+
+    @Column(name = "badge_name", nullable = false, length = 100)
+    private String badgeName;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "condition_value", nullable = false)
+    private Integer conditionValue;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/kr/co/mapspring/learning/entity/LearningGoal.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/LearningGoal.java
@@ -1,0 +1,66 @@
+package kr.co.mapspring.learning.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "learning_goal")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LearningGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "goal_id", nullable = false, updatable = false)
+    private Long goalId;
+
+    //    @ManyToMany(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "goal_type", nullable = false, length = 50)
+    private String goalType;
+
+    @Column(name = "target_value", nullable = false)
+    private Integer targetValue;
+
+    @Builder.Default
+    @Column(name = "current_value", nullable = false)
+    private Integer currentValue = 0;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}
+

--- a/src/main/java/kr/co/mapspring/learning/entity/LearningProfile.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/LearningProfile.java
@@ -1,0 +1,55 @@
+package kr.co.mapspring.learning.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "learning_profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LearningProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "learning_profile_id", nullable = false, updatable = false)
+    private Long learningProfileId;
+
+    //    @OneToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId; // fk
+
+    @Builder.Default
+    @Column(name = "level", nullable = false)
+    private Integer level = 1;
+
+    @Builder.Default
+    @Column(name = "exp", nullable = false)
+    private Integer exp = 0;
+
+    @Builder.Default
+    @Column(name = "total_study_count", nullable = false)
+    private Integer totalStudyCount = 0;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+}

--- a/src/main/java/kr/co/mapspring/learning/entity/UserBadge.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/UserBadge.java
@@ -1,0 +1,39 @@
+package kr.co.mapspring.learning.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_badge")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserBadge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_badge_id", nullable = false, updatable = false)
+    private Long userBadgeId;
+
+    //    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    //    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "badge_id", nullable = false)
+    @Column(name = "badge_id", nullable = false)
+    private Long badgeId;
+
+    @Column(name = "earned_at", nullable = false)
+    private LocalDateTime earnedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.earnedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/kr/co/mapspring/learning/enums/LearningGoalStatus.java
+++ b/src/main/java/kr/co/mapspring/learning/enums/LearningGoalStatus.java
@@ -1,0 +1,7 @@
+package kr.co.mapspring.learning.enums;
+
+public enum LearningGoalStatus {
+    ACTIVE,
+    COMPLETED,
+    FAILED
+}


### PR DESCRIPTION
## 작업내용
- Learning 도메인 엔티티 설계 및 구현
- 사용자 학습 프로필, 학습 목표, 배지, 사용자 배지 이력 엔티티 생성
- Lombok 기반 생성자 및 Builder 패턴 적용

## 변경사항
- 

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- 로컬 환경에서 DB 테이블 정상 생성 확인
- DBeaver에서 테이블 및 컬럼 매핑 확인 완료
<img width="265" height="295" alt="image" src="https://github.com/user-attachments/assets/88f13f7c-64fd-450d-8be7-3fafbc8b33e9" />

## 참고사항
- JPA 엔티티 설계 시 기본 생성자 필수 적용
- 테이블명과 엔티티 매핑 일관성 유지

