### PR TITLE
feat(user): User 엔티티 생성 및 도메인 메서드 추가

### DIFF
--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -1,0 +1,100 @@
+package kr.co.mapspring.user.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import kr.co.mapspring.user.enums.UserRole;
+import kr.co.mapspring.user.enums.UserStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Table(name = "users")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+
+public class User {
+	
+	@Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false, updatable = false)
+	private Long userId;
+	
+	@Column(name = "email",unique = true, length = 100)
+	private String email;
+	
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "nickname",unique = true, length = 50)
+	private String nickname;
+	
+	@Column(name = "password_hash", nullable = true)
+	private String passwordHash;
+	
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false)
+	private UserStatus status;
+	
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role", nullable = false)
+	private UserRole role;
+	
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+	
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+	
+	@PrePersist
+    protected void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+	
+	@PreUpdate
+	protected void preUpdate() {
+	    this.updatedAt = LocalDateTime.now();
+	}
+	
+	
+	public User(String email, String name, String nickname, String passwordHash,
+            UserStatus status, UserRole role) {
+    this.email = email;
+    this.name = name;
+    this.nickname = nickname;
+    this.passwordHash = passwordHash;
+    this.status = status;
+    this.role = role;
+}
+	
+	public void updateNickname(String nickname) {
+	    this.nickname = nickname;
+	}
+
+	public void updatePasswordHash(String passwordHash) {
+	    this.passwordHash = passwordHash;
+	}
+
+	public void updateStatus(UserStatus status) {
+	    this.status = status;
+	}
+
+	public void updateRole(UserRole role) {
+	    this.role = role;
+	}
+	
+	
+}

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -35,21 +35,21 @@ public class User {
 	@Column(name = "email",unique = true, length = 100)
 	private String email;
 	
-	@Column(name = "name", nullable = false)
+	@Column(name = "name", nullable = false, length = 50)
 	private String name;
 
 	@Column(name = "nickname",unique = true, length = 50)
 	private String nickname;
 	
-	@Column(name = "password_hash", nullable = true)
+	@Column(name = "password_hash", length = 255)
 	private String passwordHash;
 	
 	@Enumerated(EnumType.STRING)
-	@Column(name = "status", nullable = false)
+	@Column(name = "status", nullable = false, length = 20)
 	private UserStatus status;
 	
 	@Enumerated(EnumType.STRING)
-	@Column(name = "role", nullable = false)
+	@Column(name = "role", nullable = false, length = 20)
 	private UserRole role;
 	
 	@Column(name = "created_at", nullable = false)

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -70,31 +70,4 @@ public class User {
 	}
 	
 	
-	public User(String email, String name, String nickname, String passwordHash,
-            UserStatus status, UserRole role) {
-    this.email = email;
-    this.name = name;
-    this.nickname = nickname;
-    this.passwordHash = passwordHash;
-    this.status = status;
-    this.role = role;
-}
-	
-	public void updateNickname(String nickname) {
-	    this.nickname = nickname;
-	}
-
-	public void updatePasswordHash(String passwordHash) {
-	    this.passwordHash = passwordHash;
-	}
-
-	public void updateStatus(UserStatus status) {
-	    this.status = status;
-	}
-
-	public void updateRole(UserRole role) {
-	    this.role = role;
-	}
-	
-	
 }

--- a/src/main/java/kr/co/mapspring/user/enums/UserRole.java
+++ b/src/main/java/kr/co/mapspring/user/enums/UserRole.java
@@ -1,0 +1,6 @@
+package kr.co.mapspring.user.enums;
+
+public enum UserRole {
+	USER,
+	ADMIN
+}

--- a/src/main/java/kr/co/mapspring/user/enums/UserStatus.java
+++ b/src/main/java/kr/co/mapspring/user/enums/UserStatus.java
@@ -1,0 +1,8 @@
+package kr.co.mapspring.user.enums;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE,
+    SUSPENDED,
+    DELETED
+}

--- a/src/main/java/kr/co/mapspring/user/oauth/entity/OauthUser.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/entity/OauthUser.java
@@ -69,11 +69,5 @@ public class OauthUser {
 	    this.updatedAt = LocalDateTime.now();
 	}
 	
-	public OauthUser(User user, SocialProvider provider, String providerUserId, String providerEmail) {
-        this.user = user;
-        this.provider = provider;
-        this.providerUserId = providerUserId;
-        this.providerEmail = providerEmail;
-    }
 	
 }

--- a/src/main/java/kr/co/mapspring/user/oauth/entity/OauthUser.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/entity/OauthUser.java
@@ -1,0 +1,79 @@
+package kr.co.mapspring.user.oauth.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.oauth.enums.SocialProvider;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(
+	    name = "oauth_account",
+	    uniqueConstraints = {
+	        @UniqueConstraint(name = "uk_provider_provider_user_id", columnNames = {"provider", "provider_user_id"}),
+	        @UniqueConstraint(name = "uk_user_provider", columnNames = {"user_id", "provider"})
+	    }
+	)
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OauthUser {
+	@Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "oauth_account_id", nullable = false, updatable = false)
+	private Long oauthAccountId;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "provider", nullable = false, length = 20)
+	private SocialProvider provider;
+	
+	@Column(name = "provider_user_id",unique = true, length = 100)
+	private String providerUserId;
+	
+	@Column(name = "provider_email", length = 100)
+	private String providerEmail;
+	
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+	
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+	
+	@PrePersist
+    protected void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+	
+	@PreUpdate
+	protected void preUpdate() {
+	    this.updatedAt = LocalDateTime.now();
+	}
+	
+	public OauthUser(User user, SocialProvider provider, String providerUserId, String providerEmail) {
+        this.user = user;
+        this.provider = provider;
+        this.providerUserId = providerUserId;
+        this.providerEmail = providerEmail;
+    }
+	
+}

--- a/src/main/java/kr/co/mapspring/user/oauth/enums/SocialProvider.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/enums/SocialProvider.java
@@ -1,0 +1,6 @@
+package kr.co.mapspring.user.oauth.enums;
+
+public enum SocialProvider {
+	  GOOGLE,
+	  KAKAO
+}

--- a/src/main/java/kr/co/mapspring/user/oauth/test.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/test.java
@@ -1,0 +1,5 @@
+package kr.co.mapspring.user.oauth;
+
+public class test {
+
+}


### PR DESCRIPTION
## 작업내용
- User 엔티티 생성 및 도메인 메서드 추가


## 변경사항
- User 엔티티 추가
- user.enums 패키지 추가
  - UserRole enum 추가
  - UserStatus enum 추가


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="361" height="54" alt="image" src="https://github.com/user-attachments/assets/882fcf36-7c8d-4171-94f1-eb2bc4600f4e" />


<img width="899" height="603" alt="image" src="https://github.com/user-attachments/assets/5649db24-f6d1-45d3-a102-0363cb539344" />

- 로컬 DB에서 users 테이블 생성 확인
- 컬럼 매핑 결과 확인

## 참고사항
- 도메인 로직은 엔티티 내부에서 처리하였습니다
- status, role 컬럼은 각각 enum(UserStatus, UserRole)으로 관리하도록 변경했습니다
- 기본 생성자는 @NoArgsConstructor(access = AccessLevel.PROTECTED)로 제한했습니다
- userId, createdAt, updatedAt은 외부에서 직접 주입하지 않도록 설계했습니다


