### PR TITLE
feat(user): Ui/UX에 맞춰 ERD,entity 수정 / 제거 및 추가

### DIFF
--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -59,6 +59,9 @@ public class User {
 	@Column(name = "role", nullable = false, length = 20)
 	private UserRole role;
 	
+	@Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+	
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 	

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.user.entity;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access=AccessLevel.PROTECTED)
 
 
 public class User {
@@ -37,6 +38,15 @@ public class User {
 	
 	@Column(name = "name", nullable = false, length = 50)
 	private String name;
+	
+	@Column(name = "birth_date", nullable = false)
+	private LocalDate birthDate;
+	
+	@Column(name = "address", nullable = false, length = 255)
+    private String address;
+	
+	@Column(name = "phone_number", nullable = false, unique = true,length = 20)
+    private String phoneNumber;
 	
 	@Column(name = "password_hash", length = 255)
 	private String passwordHash;

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -20,14 +20,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
-@Table(name = "users")
+@Table(name="users")
 @Entity
 @Getter
 @NoArgsConstructor(access=AccessLevel.PROTECTED)
-
-
 public class User {
-	
 	@Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id", nullable = false, updatable = false)

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -37,9 +37,6 @@ public class User {
 	
 	@Column(name = "name", nullable = false, length = 50)
 	private String name;
-
-	@Column(name = "nickname",unique = true, length = 50)
-	private String nickname;
 	
 	@Column(name = "password_hash", length = 255)
 	private String passwordHash;

--- a/src/main/java/kr/co/mapspring/user/terms/Test.java
+++ b/src/main/java/kr/co/mapspring/user/terms/Test.java
@@ -1,0 +1,5 @@
+package kr.co.mapspring.user.terms;
+
+public class Test {
+
+}

--- a/src/main/java/kr/co/mapspring/user/terms/entity/Term.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/Term.java
@@ -1,0 +1,70 @@
+package kr.co.mapspring.user.terms.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import kr.co.mapspring.user.terms.enums.TermType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "terms")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Term {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "term_id", nullable = false, updatable = false)
+    private Long termId;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Lob
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "version", nullable = false, length = 20)
+    private String version;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "term_type", nullable = false, length = 30)
+    private TermType termType;
+
+    @Column(name = "is_required", nullable = false)
+    private boolean required;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @PrePersist
+    protected void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+}

--- a/src/main/java/kr/co/mapspring/user/terms/entity/Term.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/Term.java
@@ -23,7 +23,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Term {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "term_id", nullable = false, updatable = false)

--- a/src/main/java/kr/co/mapspring/user/terms/entity/UserTermAgreement.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/UserTermAgreement.java
@@ -1,0 +1,5 @@
+package kr.co.mapspring.user.terms.entity;
+
+public class UserTermAgreement {
+
+}

--- a/src/main/java/kr/co/mapspring/user/terms/entity/UserTermAgreement.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/UserTermAgreement.java
@@ -1,5 +1,61 @@
 package kr.co.mapspring.user.terms.entity;
 
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import kr.co.mapspring.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	    name = "user_term_agreement",
+	    uniqueConstraints = {
+	        @UniqueConstraint(name = "uk_user_term_agreement_user_term", columnNames = {"user_id", "term_id"})
+	    }
+	)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserTermAgreement {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_term_agreement_id", nullable = false, updatable = false)
+    private Long userTermAgreementId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term;
+
+    @Column(name = "agreed", nullable = false)
+    private boolean agreed;
+
+    @Column(name = "agreed_at", nullable = false)
+    private LocalDateTime agreedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    
+    @PrePersist
+    protected void prePersist() {
+        if (this.agreedAt == null) {
+            this.agreedAt = LocalDateTime.now();
+        }
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/kr/co/mapspring/user/terms/enums/TermType.java
+++ b/src/main/java/kr/co/mapspring/user/terms/enums/TermType.java
@@ -1,0 +1,5 @@
+package kr.co.mapspring.user.terms.enums;
+
+public class TermType {
+
+}

--- a/src/main/java/kr/co/mapspring/user/terms/enums/TermType.java
+++ b/src/main/java/kr/co/mapspring/user/terms/enums/TermType.java
@@ -1,5 +1,7 @@
 package kr.co.mapspring.user.terms.enums;
 
-public class TermType {
-
+public enum TermType {
+    SERVICE,
+    PRIVACY,
+    MARKETING
 }


### PR DESCRIPTION
## 작업내용
Ui/UX에 맞춰 ERD,entity  수정 / 제거 및 추가 


## 변경사항
<img width="436" height="148" alt="image" src="https://github.com/user-attachments/assets/8d8e7f0f-3276-4b3d-b6e6-e85f5dd97b21" />

1. 사용자 테이블  닉네임 컬럼 제거 / 생년월일.주소,전화번호 컬럼 추가 

2. 약관 마스터 정보 , 사용자 약관 동의 이력 테이블 추가

3. 사용자 테이블에 마지막 로그인 시각(lastLoginAt) 컬럼 추가

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="976" height="285" alt="image" src="https://github.com/user-attachments/assets/852eb307-75f9-4c2e-b5c3-e7725ef54eeb" />
<img width="872" height="396" alt="image" src="https://github.com/user-attachments/assets/ebac707f-3104-44a9-880d-dc99b6b56e4a" />



## 참고사항
- 현재 UI/UX 상에 보이는 받아야 할 사용자의 데이터로만 테이블을 구성 해두었습니다 
추가적으로 기능을 구현할 때 필요하신 컬럼이 있으시다면 말해주시면 추가 해두겠습니다

