### PR TITLE
feat(learning): StudyLog Entity 수정 및 enum 추가/삭제

### DIFF
--- a/src/main/java/kr/co/mapspring/learning/entity/Badge.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/Badge.java
@@ -32,6 +32,9 @@ public class Badge {
     @Column(name = "description", nullable = false)
     private String description;
 
+    @Column(name = "condition_type", nullable = false, length = 50)
+    private String conditionType;
+
     @Column(name = "condition_value", nullable = false)
     private Integer conditionValue;
 

--- a/src/main/java/kr/co/mapspring/learning/entity/GoalMaster.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/GoalMaster.java
@@ -53,10 +53,10 @@ public class GoalMaster {
     private GoalPeriodType periodType;
 
     @Column(name = "is_active", nullable = false)
-    private boolean isActive = true;
+    private boolean isActive;
 
     @Column(name = "display_order", nullable = false)
-    private Integer displayOrder = 0;
+    private Integer displayOrder;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/kr/co/mapspring/learning/entity/LearningProfile.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/LearningProfile.java
@@ -32,13 +32,13 @@ public class LearningProfile {
     private User user;
 
     @Column(name = "level", nullable = false)
-    private Integer level = 1;
+    private Integer level;
 
     @Column(name = "exp", nullable = false)
-    private Integer exp = 0;
+    private Integer exp;
 
     @Column(name = "total_study_count", nullable = false)
-    private Integer totalStudyCount = 0;
+    private Integer totalStudyCount;
 
 
 }

--- a/src/main/java/kr/co/mapspring/learning/entity/StudyLog.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/StudyLog.java
@@ -1,0 +1,58 @@
+package kr.co.mapspring.learning.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kr.co.mapspring.learning.enums.StudyType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "study_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_log_id", nullable = false, updatable = false)
+    private Long studyLogId;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "place_id", nullable = false)
+    @Column(name = "place_id", nullable = false)
+    private Long placeId;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "scenario_id", nullable = false)
+    @Column(name = "scenario_id", nullable = false)
+    private Long scenarioId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "study_type", nullable = false, length = 50)
+    private StudyType studyType;
+
+    @Column(name = "earned_exp", nullable = false)
+    private Integer earnedExp;
+
+    @Column(name = "study_duration_sec", nullable = false)
+    private Integer studyDurationSec;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+
+}

--- a/src/main/java/kr/co/mapspring/learning/entity/UserGoal.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/UserGoal.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserGoal {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_goal_id", nullable = false, updatable = false)
@@ -43,11 +44,11 @@ public class UserGoal {
     private GoalMaster goalMaster;
 
     @Column(name = "current_value", nullable = false)
-    private Integer currentValue = 0;
+    private Integer currentValue;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    private UserGoalStatus status = UserGoalStatus.ACTIVE;
+    private UserGoalStatus status;
 
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
@@ -76,13 +77,16 @@ public class UserGoal {
     }
 
     // !! TEST STATIC FACTORY !!
-    public static UserGoal create(Long userId, GoalMaster goalMaster) {
+    public static UserGoal create(Long userId, GoalMaster goalMaster, LocalDate startDate, LocalDate endDate) {
         UserGoal userGoal = new UserGoal();
         userGoal.userId = userId;
         userGoal.goalMaster = goalMaster;
         userGoal.currentValue = 0;
         userGoal.status = UserGoalStatus.ACTIVE;
-        userGoal.startDate = LocalDate.now();
+        userGoal.startDate = startDate;
+        userGoal.endDate = endDate;
+        userGoal.createdAt = LocalDateTime.now();
+        userGoal.updatedAt = LocalDateTime.now();
         return userGoal;
     }
 

--- a/src/main/java/kr/co/mapspring/learning/enums/LearningGoalStatus.java
+++ b/src/main/java/kr/co/mapspring/learning/enums/LearningGoalStatus.java
@@ -1,7 +1,0 @@
-package kr.co.mapspring.learning.enums;
-
-public enum LearningGoalStatus {
-    ACTIVE,
-    COMPLETED,
-    FAILED
-}

--- a/src/main/java/kr/co/mapspring/learning/enums/StudyType.java
+++ b/src/main/java/kr/co/mapspring/learning/enums/StudyType.java
@@ -1,0 +1,8 @@
+package kr.co.mapspring.learning.enums;
+
+public enum StudyType {
+    PLACE,
+    SCENARIO,
+    SPEAKING,
+    PRONUNCIATION
+}


### PR DESCRIPTION
## 작업내용
- 학습 도메인 엔티티 구조를 DB 스키마에 맞게 수정
- 목표 선택 기능 구현을 위한 엔티티 구조 보완

## 변경사항
- 기존 엔티티 컬럼 수정 및 매핑 구조 개선
- LearningProfile, StudyLog 엔티티 추가
- GoalMaster, UserGoal, Badge, UserBadge 엔티티 일부 필드 및 매핑 수정
- GoalType, GoalPeriodType, StudyType, UserGoalStatus enum 정리 및 불필요한 enum 제거

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [v] DB 생성 확인 완료
<img width="310" height="419" alt="image" src="https://github.com/user-attachments/assets/8928505d-2472-4518-a9cf-cdb3f9230993" />

## 참고사항
- user_id는 임시로 Long 타입 유지 (추후 조인 예정)
- enum은 EnumType.STRING 방식으로 통일
- 엔티티는 최소한의 어노테이션만 사용하도록 정리
- 불필요한 enum(LearningGoalStatus) 제거

