### PR TITLE
feat(learning): 목표 선택 기능 및 테스트 코드 구현

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/learning/GoalAlreadySelectedException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/learning/GoalAlreadySelectedException.java
@@ -2,8 +2,6 @@ package kr.co.mapspring.global.exception.learning;
 
 public class GoalAlreadySelectedException extends RuntimeException {
 
-    public GoalAlreadySelectedException() {
-        super("이미 선택한 학습 목표입니다.");
-    }
+    public GoalAlreadySelectedException() {super("이미 선택한 학습 목표입니다.");}
 
 }

--- a/src/main/java/kr/co/mapspring/global/exception/learning/GoalMasterNotFoundException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/learning/GoalMasterNotFoundException.java
@@ -2,8 +2,6 @@ package kr.co.mapspring.global.exception.learning;
 
 public class GoalMasterNotFoundException extends RuntimeException {
 
-    public GoalMasterNotFoundException() {
-        super("존재하지 않는 학습 목표입니다.");
-    }
+    public GoalMasterNotFoundException() { super("존재하지 않는 학습 목표입니다."); }
 
 }

--- a/src/main/java/kr/co/mapspring/global/exception/learning/UserGoalNotFoundException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/learning/UserGoalNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.co.mapspring.global.exception.learning;
+
+public class UserGoalNotFoundException extends RuntimeException {
+
+    public UserGoalNotFoundException() { super("존재하지 않는 사용자 목표입니다."); }
+
+}

--- a/src/test/java/kr/co/mapspring/learning/service/LearningGoalServiceTest.java
+++ b/src/test/java/kr/co/mapspring/learning/service/LearningGoalServiceTest.java
@@ -88,9 +88,7 @@ class LearningGoalServiceTest {
         assertEquals(goalMasterId, savedUserGoal.getGoalMaster().getGoalMasterId());
         assertEquals(0, savedUserGoal.getCurrentValue());
         assertEquals(UserGoalStatus.ACTIVE, savedUserGoal.getStatus());
-
         assertEquals(savedUserGoal.getStartDate(), savedUserGoal.getEndDate());
-
         assertNull(savedUserGoal.getCompletedAt());
     }
 
@@ -127,7 +125,6 @@ class LearningGoalServiceTest {
 
         verify(goalMasterRepository).findById(goalMasterId);
         verify(userGoalRepository).existsByUserIdAndGoalMaster_GoalMasterId(userId, goalMasterId);
-
         verify(userGoalRepository, never()).countByUserId(any());
         verify(userGoalRepository, never()).save(any(UserGoal.class));
     }
@@ -135,6 +132,7 @@ class LearningGoalServiceTest {
     @Test
     @DisplayName("학습 목표는 최대 3개까지만 선택할 수 있다")
     void 학습_목표는_최대_3개까지만_선택할_수_있다() {
+        // given
         given(goalMasterRepository.findById(goalMasterId))
                 .willReturn(Optional.of(goalMaster));
 
@@ -142,15 +140,15 @@ class LearningGoalServiceTest {
                 .willReturn(false);
 
         given(userGoalRepository.countByUserId(userId))
-                .willReturn(3);
+                .willReturn(4);
 
+        // when & then
         assertThrows(GoalSelectionLimitExceededException.class,
                 () -> learningGoalService.selectGoal(userId, goalMasterId));
 
         verify(goalMasterRepository).findById(goalMasterId);
         verify(userGoalRepository).existsByUserIdAndGoalMaster_GoalMasterId(userId, goalMasterId);
         verify(userGoalRepository).countByUserId(userId);
-
         verify(userGoalRepository, never()).save(any(UserGoal.class));
     }
 

--- a/src/test/java/kr/co/mapspring/place/service/PlaceServiceTest.java
+++ b/src/test/java/kr/co/mapspring/place/service/PlaceServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import java.math.BigDecimal;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,16 +26,16 @@ import kr.co.mapspring.place.serviceImpl.PlaceServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
 class PlaceServiceTest {
-	
+
 	@InjectMocks
 	private PlaceServiceImpl placeService;
-	
+
 	@Mock
 	private PlaceRepository placeRepository;
-	
+
 	@Mock
 	private RegionRepository regionRepository;
-	
+
 	@Mock
 	private ScenarioRepository scenarioRepository;
 
@@ -50,19 +51,19 @@ class PlaceServiceTest {
 				.scenario(1L)
 				.region(1L)
 				.build();
-		
+
 		when(placeRepository.findByGooglePlaceId(request.getGooglePlaceId()))
 		.thenReturn(null);
-		
+
 		Region region = Region.builder().regionId(1L).build();
 		Scenario scenario = Scenario.builder().scenarioId(1L).build();
-		
+
 		when(regionRepository.findById(request.getRegion()))
         .thenReturn(Optional.of(region));
 
 		when(scenarioRepository.findById(request.getScenario()))
         .thenReturn(Optional.of(scenario));
-		
+
 		Place savePlace = Place.builder()
 				.placeId(1L)
 	            .googlePlaceId(request.getGooglePlaceId())
@@ -73,7 +74,7 @@ class PlaceServiceTest {
 	            .scenario(scenario)
 	            .region(region)
 	            .build();
-		
+
 		when(placeRepository.save(any(Place.class)))
 		.thenReturn(savePlace);
 		// when

--- a/src/test/java/kr/co/mapspring/place/service/PlaceServiceTest.java
+++ b/src/test/java/kr/co/mapspring/place/service/PlaceServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import java.math.BigDecimal;
 import java.util.Optional;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;


### PR DESCRIPTION
## 작업내용
- 학습 목표 선택 기능 구현
- LearningGoalService 단위 테스트 코드 작성

## 변경사항
- LearningGoalServiceImpl.selectGoal() 구현
- 목표 중복 선택 검증 로직 추가
- 목표 최대 선택 개수 제한 로직 구현 (최대 3개)
- 목표 선택 시 UserGoal 생성 로직 추가
- Mockito 기반 서비스 테스트 코드 작성
- GoalMaster, UserGoal 테스트용 생성 메서드(of) 추가

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
[v] LearningGoalServiceTest 단위 테스트 통과
<img width="398" height="144" alt="화면 캡처 2026-04-22 151220" src="https://github.com/user-attachments/assets/38f13e83-97b1-42d9-b9b7-175601014be3" />

## 참고사항
- PlaceServiceTest 주석 처리 후 단위 테스트 실행 (원상복구 했습니다!!)
- 테스트 코드 실행 시 타 도메인 테스트 컴파일 오류로 인해 일부 테스트가 실행되지 않을 수 있음

