### PR TITLE
feat(learning): 목표 해제 및 진행 중 목표 조회 기능 구현

### DIFF
--- a/src/main/java/kr/co/mapspring/learning/repository/UserGoalRepository.java
+++ b/src/main/java/kr/co/mapspring/learning/repository/UserGoalRepository.java
@@ -1,12 +1,17 @@
 package kr.co.mapspring.learning.repository;
 
 import kr.co.mapspring.learning.entity.UserGoal;
+import kr.co.mapspring.learning.enums.UserGoalStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface UserGoalRepository extends JpaRepository<UserGoal, Long> {
 
     boolean existsByUserIdAndGoalMaster_GoalMasterId(Long userId, Long goalMasterId);
 
     int countByUserId(Long userId);
+
+    List<UserGoal> findAllByUserIdAndStatus(Long userId, UserGoalStatus status);
 
 }

--- a/src/main/java/kr/co/mapspring/learning/service/LearningGoalService.java
+++ b/src/main/java/kr/co/mapspring/learning/service/LearningGoalService.java
@@ -1,11 +1,38 @@
 package kr.co.mapspring.learning.service;
 
+import kr.co.mapspring.learning.entity.UserGoal;
+
+import java.util.List;
+
 public interface LearningGoalService {
 
     /**
+     * 사용자가 학습 목표를 선택한다.
      *
-     * @param userId
-     * @param goalmasterId
+     * - 동일한 목표는 중복 선택할 수 없다.
+     * - 최대 3개의 목표까지만 선택 가능하다.
+     *
+     * @param userId 사용자 ID
+     * @param goalMasterId 선택할 목표 ID
      */
-    void selectGoal(Long userId, Long goalmasterId);
+    void selectGoal(Long userId, Long goalMasterId);
+
+    /**
+     * 사용자가 선택한 학습 목표를 해제한다.
+     *
+     * 목표를 삭제하지 않고 상태를 CANCELED로 변경한다.
+     *
+     * @param userGoalId 사용자 목표 ID
+     */
+    void cancelGoal(Long userGoalId);
+
+    /**
+     * 사용자의 진행 중인 학습 목표 목록을 조회한다.
+     *
+     * 진행 중 상태(ACTIVE)인 목표만 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @return 진행 중인 사용자 목표 목록
+     */
+    List<UserGoal> getActiveGoals(Long userId);
 }

--- a/src/main/java/kr/co/mapspring/learning/service/impl/LearningGoalServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/learning/service/impl/LearningGoalServiceImpl.java
@@ -3,9 +3,11 @@ package kr.co.mapspring.learning.service.impl;
 import kr.co.mapspring.global.exception.learning.GoalAlreadySelectedException;
 import kr.co.mapspring.global.exception.learning.GoalMasterNotFoundException;
 import kr.co.mapspring.global.exception.learning.GoalSelectionLimitExceededException;
+import kr.co.mapspring.global.exception.learning.UserGoalNotFoundException;
 import kr.co.mapspring.learning.entity.GoalMaster;
 import kr.co.mapspring.learning.entity.UserGoal;
 import kr.co.mapspring.learning.enums.GoalPeriodType;
+import kr.co.mapspring.learning.enums.UserGoalStatus;
 import kr.co.mapspring.learning.repository.GoalMasterRepository;
 import kr.co.mapspring.learning.repository.UserGoalRepository;
 import kr.co.mapspring.learning.service.LearningGoalService;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -50,6 +53,20 @@ public class LearningGoalServiceImpl implements LearningGoalService {
         UserGoal userGoal = UserGoal.of(userId, goalMaster, startDate, endDate);
 
         userGoalRepository.save(userGoal);
+    }
+
+    @Override
+    @Transactional
+    public void cancelGoal(Long userGoalId) {
+        UserGoal userGoal = userGoalRepository.findById(userGoalId)
+                .orElseThrow(UserGoalNotFoundException::new);
+
+        userGoal.cancel();
+    }
+
+    @Override
+    public List<UserGoal> getActiveGoals(Long userId) {
+        return userGoalRepository.findAllByUserIdAndStatus(userId, UserGoalStatus.ACTIVE);
     }
 
     private LocalDate calcultateEndDate(LocalDate startDate, GoalMaster goalMaster) {

--- a/src/test/java/kr/co/mapspring/learning/service/LearningGoalServiceTest.java
+++ b/src/test/java/kr/co/mapspring/learning/service/LearningGoalServiceTest.java
@@ -3,10 +3,10 @@ package kr.co.mapspring.learning.service;
 import kr.co.mapspring.global.exception.learning.GoalAlreadySelectedException;
 import kr.co.mapspring.global.exception.learning.GoalMasterNotFoundException;
 import kr.co.mapspring.global.exception.learning.GoalSelectionLimitExceededException;
+import kr.co.mapspring.global.exception.learning.UserGoalNotFoundException;
 import kr.co.mapspring.learning.entity.GoalMaster;
 import kr.co.mapspring.learning.entity.UserGoal;
 import kr.co.mapspring.learning.enums.GoalPeriodType;
-import kr.co.mapspring.learning.enums.GoalType;
 import kr.co.mapspring.learning.enums.UserGoalStatus;
 import kr.co.mapspring.learning.repository.GoalMasterRepository;
 import kr.co.mapspring.learning.repository.UserGoalRepository;
@@ -20,7 +20,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Period;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -150,6 +149,78 @@ class LearningGoalServiceTest {
         verify(userGoalRepository).existsByUserIdAndGoalMaster_GoalMasterId(userId, goalMasterId);
         verify(userGoalRepository).countByUserId(userId);
         verify(userGoalRepository, never()).save(any(UserGoal.class));
+    }
+
+    @Test
+    @DisplayName("진행 중인 목표를 정상적으로 해제한다")
+    void 진행_중인_목표를_정상적으로_해제한다() {
+        // given
+        Long userGoalId = 10L;
+        UserGoal userGoal = UserGoal.of(
+                userId,
+                goalMaster,
+                java.time.LocalDate.now(),
+                java.time.LocalDate.now()
+        );
+
+        given(userGoalRepository.findById(userGoalId))
+                .willReturn(Optional.of(userGoal));
+
+        // when
+        learningGoalService.cancelGoal(userGoalId);
+
+        // then
+        verify(userGoalRepository).findById(userGoalId);
+        assertEquals(UserGoalStatus.CANCELED, userGoal.getStatus());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 목표는 해제할 수 없다")
+    void 존재하지_않는_사용자_목표는_해제할_수_없다() {
+        // given
+        Long userGoalId = 999L;
+
+        given(userGoalRepository.findById(userGoalId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(UserGoalNotFoundException.class,
+                () -> learningGoalService.cancelGoal(userGoalId));
+
+        verify(userGoalRepository).findById(userGoalId);
+    }
+
+    @Test
+    @DisplayName("사용자의 진행 중인 목표 목록을 조회한다")
+    void 사용자의_진행_중인_목표_목록을_조회한다() {
+        // given
+        UserGoal activeGoal1 = UserGoal.of(
+                userId,
+                goalMaster,
+                java.time.LocalDate.now(),
+                java.time.LocalDate.now()
+        );
+
+        UserGoal activeGoal2 = UserGoal.of(
+                userId,
+                goalMaster,
+                java.time.LocalDate.now(),
+                java.time.LocalDate.now()
+        );
+
+        given(userGoalRepository.findAllByUserIdAndStatus(userId, UserGoalStatus.ACTIVE))
+                .willReturn(java.util.List.of(activeGoal1, activeGoal2));
+
+        // when
+        java.util.List<UserGoal> result = learningGoalService.getActiveGoals(userId);
+
+        // then
+        verify(userGoalRepository).findAllByUserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        assertEquals(2, result.size());
+        assertEquals(UserGoalStatus.ACTIVE, result.get(0).getStatus());
+        assertEquals(UserGoalStatus.ACTIVE, result.get(1).getStatus());
+
+
     }
 
 }


### PR DESCRIPTION
## 작업내용
- 학습 목표 해제 기능 구현
- 진행 중 목표 조회 기능 구현
- 관련 서비스 단위 테스트 코드 작성


## 변경사항
- LearningGoalServiceImpl.cancelGoal() 구현
- LearningGoalServiceImpl.getActiveGoals() 구현
- UserGoalRepository에 진행 목표 조회 메서드 추가
- 목표 해제 및 진행 목표 조회 테스트 코드 작성


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [v] 목표 해제 기능 테스트 통과
- [v] 진행 중 목표 조회 테스트 통과
<img width="425" height="193" alt="image" src="https://github.com/user-attachments/assets/daee584d-71e4-41ac-b102-b68a34a546b8" />


## 참고사항
- 목표 해제 시 데이터를 삭제하지 않고 상태(CANCELED)만 변경하도록 설계
- 진행 중 목표 조회는 ACTIVE 상태 기준으로 조회하도록 구현

