### PR TITLE
feat(user): 로그인 기능 완료 및 Swaager 문서화 작업 완료

### DIFF
--- a/src/main/java/kr/co/mapspring/user/controller/AuthController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/AuthController.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 
-    // 로그인 비즈니스 로직은 서비스가 담당한다.
     private final LoginService loginService;
 
     @PostMapping("/login")
@@ -23,6 +22,7 @@ public class AuthController {
             @RequestBody LoginDto.RequestLogin request
     ) {
         LoginDto.ResponseLogin response = loginService.login(request);
+        
         return ApiResponseDTO.success("로그인 성공", response);
     }
 }

--- a/src/main/java/kr/co/mapspring/user/controller/AuthController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/AuthController.java
@@ -1,0 +1,28 @@
+package kr.co.mapspring.user.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.user.dto.LoginDto;
+import kr.co.mapspring.user.service.LoginService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    // 로그인 비즈니스 로직은 서비스가 담당한다.
+    private final LoginService loginService;
+
+    @PostMapping("/login")
+    public ApiResponseDTO<LoginDto.ResponseLogin> login(
+            @RequestBody LoginDto.RequestLogin request
+    ) {
+        LoginDto.ResponseLogin response = loginService.login(request);
+        return ApiResponseDTO.success("로그인 성공", response);
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
@@ -1,0 +1,101 @@
+package kr.co.mapspring.user.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.user.dto.LoginDto;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+public interface AuthControllerDocs {
+
+    @Operation(
+            summary = "로그인",
+            description = "이메일과 비밀번호를 입력받아 로그인 처리하고 사용자 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 이메일",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "USER_NOT_FOUND",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 404,
+                                              "message": "존재하지 않는 이메일입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "비밀번호 불일치",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "INVALID_PASSWORD",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 401,
+                                              "message": "비밀번호가 일치하지 않습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "비활성 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "INACTIVE_USER",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 403,
+                                              "message": "비활성 사용자입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponseDTO<LoginDto.ResponseLogin> login(
+            @RequestBody(
+                    description = "로그인 요청 정보",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LoginDto.RequestLogin.class),
+                            examples = @ExampleObject(
+                                    name = "로그인 요청 예시",
+                                    value = """
+                                            {
+                                              "email": "test@naver.com",
+                                              "password": "1234"
+                                            }
+                                            """
+                            )
+                    )
+            )
+            LoginDto.RequestLogin request
+    );
+}

--- a/src/main/java/kr/co/mapspring/user/dto/LoginDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/LoginDto.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.mapspring.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,10 +12,13 @@ public class LoginDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
+    @Schema(description = "로그인 요청 DTO")
     public static class RequestLogin {
 
+        @Schema(description = "사용자 이메일", example = "test@naver.com")
         private String email;
 
+        @Schema(description = "사용자 비밀번호", example = "1234")
         private String password;
     }
 
@@ -22,16 +26,22 @@ public class LoginDto {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    @Schema(description = "로그인 응답 DTO")
     public static class ResponseLogin {
 
+        @Schema(description = "사용자 ID", example = "1")
         private Long userId;
 
+        @Schema(description = "사용자 이메일", example = "test@naver.com")
         private String email;
 
+        @Schema(description = "사용자 이름", example = "홍길동")
         private String name;
 
+        @Schema(description = "사용자 권한", example = "USER")
         private String role;
 
+        // Entity -> Response DTO 변환
         public static ResponseLogin from(User user) {
             return ResponseLogin.builder()
                     .userId(user.getUserId())

--- a/src/main/java/kr/co/mapspring/user/dto/LoginDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/LoginDto.java
@@ -1,6 +1,8 @@
 package kr.co.mapspring.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import kr.co.mapspring.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,10 +16,13 @@ public class LoginDto {
     @NoArgsConstructor
     @Schema(description = "로그인 요청 DTO")
     public static class RequestLogin {
-
+    	
+    	@NotBlank(message = "이메일은 필수 입력 값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
         @Schema(description = "사용자 이메일", example = "test@naver.com")
         private String email;
-
+    	
+    	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
         @Schema(description = "사용자 비밀번호", example = "1234")
         private String password;
     }
@@ -31,7 +36,8 @@ public class LoginDto {
 
         @Schema(description = "사용자 ID", example = "1")
         private Long userId;
-
+        
+        
         @Schema(description = "사용자 이메일", example = "test@naver.com")
         private String email;
 

--- a/src/test/java/kr/co/mapspring/PasswordTest.java
+++ b/src/test/java/kr/co/mapspring/PasswordTest.java
@@ -1,0 +1,12 @@
+package kr.co.mapspring;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class PasswordTest {
+    @Test
+    void generatePasswordHash() {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        System.out.println(encoder.encode("1234"));
+    }
+}

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -8,23 +8,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+import kr.co.mapspring.global.exception.GlobalExceptionHandler;
 import kr.co.mapspring.user.dto.LoginDto;
 import kr.co.mapspring.user.service.LoginService;
 
 @WebMvcTest(AuthController.class)
+// Security filter 때문에 401/403이 뜨면 이 설정이 도움이 된다.
+@AutoConfigureMockMvc(addFilters = false)
+// 전역 예외 처리기도 같이 테스트에 포함시킨다.
+@Import(GlobalExceptionHandler.class)
 class AuthControllerTest {
 
-    // 가짜 HTTP 요청을 보내고 응답을 검증하는 도구
     @Autowired
     private MockMvc mockMvc;
 
-    // AuthController 내부에서 사용하는 LoginService를 mock으로 대체한다.
-    // 즉 실제 로그인 로직은 안 타고, 컨트롤러 동작만 본다.
+    // 컨트롤러가 의존하는 서비스는 mock으로 대체한다.
     @MockitoBean
     private LoginService loginService;
 
@@ -32,21 +40,19 @@ class AuthControllerTest {
     @DisplayName("로그인 요청이 성공하면 공통 성공 응답을 반환한다")
     void loginSuccess() throws Exception {
         // given
-        // 서비스가 성공적으로 로그인했을 때 반환할 응답 객체를 미리 만든다.
+        // 서비스가 정상 로그인 결과를 반환한다고 가정한다.
         LoginDto.ResponseLogin response = LoginDto.ResponseLogin.builder()
-                .userId(1L)                     // 응답 userId
-                .email("test@naver.com")       // 응답 email
-                .name("홍길동")                  // 응답 name
-                .role("USER")                  // 응답 role
+                .userId(1L)
+                .email("test@naver.com")
+                .name("홍길동")
+                .role("USER")
                 .build();
 
-        // loginService.login(...)이 호출되면 위 response를 반환하도록 mock 동작을 지정한다.
-        // any(LoginDto.RequestLogin.class)는 어떤 RequestLogin이 와도 상관없다는 뜻이다.
-        given(loginService.login(org.mockito.ArgumentMatchers.any(LoginDto.RequestLogin.class)))
+        // 어떤 로그인 요청이 오든 위 응답을 반환하도록 mock 설정
+        given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
                 .willReturn(response);
 
-        // 실제 HTTP 요청 body로 보낼 JSON 문자열이다.
-        // email, password를 담아서 컨트롤러에 전송한다.
+        // 실제 요청 body 역할을 하는 JSON 문자열
         String requestBody = """
                 {
                   "email": "test@naver.com",
@@ -55,19 +61,100 @@ class AuthControllerTest {
                 """;
 
         // when & then
-        // /api/auth/login 으로 POST 요청을 보낸다.
         mockMvc.perform(post("/api/auth/login")
-                        // 요청의 Content-Type이 JSON임을 명시한다.
+                        // 요청 데이터가 JSON임을 명시
                         .contentType(APPLICATION_JSON)
-                        // 위에서 만든 JSON 문자열을 요청 body로 넣는다.
+                        // 요청 body 삽입
                         .content(requestBody))
-                // 응답 HTTP status가 200 OK인지 확인
+                // HTTP 상태코드 200 확인
                 .andExpect(status().isOk())
+                // 공통 응답 구조 확인
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("로그인 성공"))
+                // 실제 data 값 확인
+                .andExpect(jsonPath("$.data.userId").value(1))
                 .andExpect(jsonPath("$.data.email").value("test@naver.com"))
                 .andExpect(jsonPath("$.data.name").value("홍길동"))
                 .andExpect(jsonPath("$.data.role").value("USER"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일이면 404 실패 응답을 반환한다")
+    void loginFailWhenUserNotFound() throws Exception {
+        // given
+        // 서비스가 USER_NOT_FOUND 예외를 던진다고 가정한다.
+        given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
+                .willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String requestBody = """
+                {
+                  "email": "notfound@naver.com",
+                  "password": "1234"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                // USER_NOT_FOUND는 ErrorCode 기준 404
+                .andExpect(status().isNotFound())
+                // 공통 실패 응답 구조 확인
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 이메일입니다."));
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 401 실패 응답을 반환한다")
+    void loginFailWhenPasswordInvalid() throws Exception {
+        // given
+        // 서비스가 INVALID_PASSWORD 예외를 던진다고 가정한다.
+        given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
+                .willThrow(new CustomException(ErrorCode.INVALID_PASSWORD));
+
+        String requestBody = """
+                {
+                  "email": "test@naver.com",
+                  "password": "wrongPassword"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                // INVALID_PASSWORD는 ErrorCode 기준 401
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("비밀번호가 일치하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("사용자 상태가 ACTIVE가 아니면 403 실패 응답을 반환한다")
+    void loginFailWhenInactiveUser() throws Exception {
+        // given
+        // 서비스가 INACTIVE_USER 예외를 던진다고 가정한다.
+        given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
+                .willThrow(new CustomException(ErrorCode.INACTIVE_USER));
+
+        String requestBody = """
+                {
+                  "email": "test@naver.com",
+                  "password": "1234"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                // INACTIVE_USER는 ErrorCode 기준 403
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.message").value("비활성 사용자입니다."));
     }
 }

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -1,0 +1,73 @@
+package kr.co.mapspring.user.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import kr.co.mapspring.user.dto.LoginDto;
+import kr.co.mapspring.user.service.LoginService;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    // 가짜 HTTP 요청을 보내고 응답을 검증하는 도구
+    @Autowired
+    private MockMvc mockMvc;
+
+    // AuthController 내부에서 사용하는 LoginService를 mock으로 대체한다.
+    // 즉 실제 로그인 로직은 안 타고, 컨트롤러 동작만 본다.
+    @MockitoBean
+    private LoginService loginService;
+
+    @Test
+    @DisplayName("로그인 요청이 성공하면 공통 성공 응답을 반환한다")
+    void loginSuccess() throws Exception {
+        // given
+        // 서비스가 성공적으로 로그인했을 때 반환할 응답 객체를 미리 만든다.
+        LoginDto.ResponseLogin response = LoginDto.ResponseLogin.builder()
+                .userId(1L)                     // 응답 userId
+                .email("test@naver.com")       // 응답 email
+                .name("홍길동")                  // 응답 name
+                .role("USER")                  // 응답 role
+                .build();
+
+        // loginService.login(...)이 호출되면 위 response를 반환하도록 mock 동작을 지정한다.
+        // any(LoginDto.RequestLogin.class)는 어떤 RequestLogin이 와도 상관없다는 뜻이다.
+        given(loginService.login(org.mockito.ArgumentMatchers.any(LoginDto.RequestLogin.class)))
+                .willReturn(response);
+
+        // 실제 HTTP 요청 body로 보낼 JSON 문자열이다.
+        // email, password를 담아서 컨트롤러에 전송한다.
+        String requestBody = """
+                {
+                  "email": "test@naver.com",
+                  "password": "1234"
+                }
+                """;
+
+        // when & then
+        // /api/auth/login 으로 POST 요청을 보낸다.
+        mockMvc.perform(post("/api/auth/login")
+                        // 요청의 Content-Type이 JSON임을 명시한다.
+                        .contentType(APPLICATION_JSON)
+                        // 위에서 만든 JSON 문자열을 요청 body로 넣는다.
+                        .content(requestBody))
+                // 응답 HTTP status가 200 OK인지 확인
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("로그인 성공"))
+                .andExpect(jsonPath("$.data.email").value("test@naver.com"))
+                .andExpect(jsonPath("$.data.name").value("홍길동"))
+                .andExpect(jsonPath("$.data.role").value("USER"));
+    }
+}


### PR DESCRIPTION
## 작업내용

- 로그인 기능 서비스 로직 구현 완료
- 로그인시 응답/ 응답 실패 시나리오 대한 단위 테스트 작성
- AuthController 생성
- Swagger 문서화 및 Controller docs 작성
- 테스트용 BCrypt("1234") 코드 작성

## 변경사항

- Swagger 문서화 추가 
- Controller (AuthController ) 추가
- Controller docs 추가

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="755" height="144" alt="image" src="https://github.com/user-attachments/assets/5cdf6de6-7716-4b3a-a427-a296c8fbbcd8" />
<img width="862" height="82" alt="image" src="https://github.com/user-attachments/assets/ccb28b7a-1de7-4866-9f24-e4d793d9fd66" />
<img width="867" height="81" alt="image" src="https://github.com/user-attachments/assets/c72bfd0d-f6a6-4d6a-8a15-7de858955c75" />



## 참고사항
테스트용 더미값입니다

INSERT INTO users (
    email,
    name,
    birth_date,
    address,
    phone_number,
    password_hash,
    status,
    role,
    last_login_at,
    created_at,
    updated_at
) VALUES (
    'test@naver.com',
    '홍길동',
    '2000-01-01',
    '서울시 강남구',
    '010-9999-1234',
    '여기에 encoder.encode("1234") 결과 붙여넣기',
    'ACTIVE',
    'USER',
    NULL,
    NOW(),
    NOW()
);

**encoder.encode("1234") 값은 test.mapspring 패키지 내부에
BCrypt 추출 코드 생성 해두었습니다 각자 추출해서 테스트하시면 될 꺼 같습니다!**
<img width="284" height="88" alt="image" src="https://github.com/user-attachments/assets/bf82901e-baad-4000-9b08-f3f97b7a3312" />



