### PR TITLE
feat(favorite): 즐겨찾기 기능 구현 (장소, 시나리오)

### DIFF
--- a/src/main/java/kr/co/mapspring/favorite/Test.java
+++ b/src/main/java/kr/co/mapspring/favorite/Test.java
@@ -1,4 +1,0 @@
-package kr.co.mapspring.favorite;
-
-public class Test {
-}

--- a/src/main/java/kr/co/mapspring/favorite/entity/FavoritePlace.java
+++ b/src/main/java/kr/co/mapspring/favorite/entity/FavoritePlace.java
@@ -50,4 +50,15 @@ public class FavoritePlace {
         this.createdAt = LocalDateTime.now();
     }
 
+    // 테스트 전용 메서드
+    public static FavoritePlace of(Long favoritePlaceId, Long userId, Long placeId) {
+        FavoritePlace favoritePlace = new FavoritePlace();
+        favoritePlace.favoritePlaceId = favoritePlaceId;
+        favoritePlace.userId = userId;
+        favoritePlace.placeId = placeId;
+        favoritePlace.createdAt = LocalDateTime.now();
+        return favoritePlace;
+    }
+
+
 }

--- a/src/main/java/kr/co/mapspring/favorite/entity/FavoritePlace.java
+++ b/src/main/java/kr/co/mapspring/favorite/entity/FavoritePlace.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,12 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "favorite_place")
+@Table(
+        name = "favorite_place",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_favorite_place_user_place", columnNames = {"user_id", "place_id"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FavoritePlace {

--- a/src/main/java/kr/co/mapspring/favorite/entity/FavoritePlace.java
+++ b/src/main/java/kr/co/mapspring/favorite/entity/FavoritePlace.java
@@ -1,0 +1,53 @@
+package kr.co.mapspring.favorite.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "favorite_place")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoritePlace {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @Column(name = "favorite_place_id", nullable = false, updatable = false)
+    private Long favoritePlaceId;
+
+//    TODO: 추후 엔티티 확정 시 연관관계로 매핑 예정
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+//    TODO: 추후 Place 엔티티 확정 시 연관관계로 변경 예정
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "place_id", nullable = false)
+    @Column(name = "place_id", nullable = false)
+    private Long placeId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static FavoritePlace create(Long userId, Long placeId) {
+        FavoritePlace favoritePlace = new FavoritePlace();
+        favoritePlace.userId = userId;
+        favoritePlace.placeId = placeId;
+        return favoritePlace;
+    }
+
+    @PrePersist
+    protected void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/kr/co/mapspring/favorite/entity/FavoriteScenario.java
+++ b/src/main/java/kr/co/mapspring/favorite/entity/FavoriteScenario.java
@@ -1,0 +1,52 @@
+package kr.co.mapspring.favorite.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "favorite_scenario")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteScenario {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "favorite_scenario_id", nullable = false, updatable = false)
+    private Long favoriteScenarioId;
+
+//    TODO: 추후 엔티티 확정 시 연관관계로 매핑 예정
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+//    TODO: 추후 엔티티 확정 시 연관관계로 매핑 예정
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "scenario_id", nullable = false)
+    @Column(name = "scenario_id", nullable = false)
+    private Long scenarioId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static FavoriteScenario create(Long userId, Long scenarioId) {
+        FavoriteScenario favoriteScenario = new FavoriteScenario();
+        favoriteScenario.userId = userId;
+        favoriteScenario.scenarioId = scenarioId;
+        return favoriteScenario;
+    }
+
+    @PrePersist
+    protected void perPersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/kr/co/mapspring/favorite/entity/FavoriteScenario.java
+++ b/src/main/java/kr/co/mapspring/favorite/entity/FavoriteScenario.java
@@ -49,4 +49,14 @@ public class FavoriteScenario {
     protected void perPersist() {
         this.createdAt = LocalDateTime.now();
     }
+
+    // 테스트 전용 메서드
+    public static FavoriteScenario of(Long favoriteScenarioId, Long userId, Long scenarioId) {
+        FavoriteScenario favoriteScenario = new FavoriteScenario();
+        favoriteScenario.favoriteScenarioId = favoriteScenarioId;
+        favoriteScenario.userId = userId;
+        favoriteScenario.scenarioId = scenarioId;
+        favoriteScenario.createdAt = LocalDateTime.now();
+        return favoriteScenario;
+    }
 }

--- a/src/main/java/kr/co/mapspring/favorite/entity/FavoriteScenario.java
+++ b/src/main/java/kr/co/mapspring/favorite/entity/FavoriteScenario.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,12 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "favorite_scenario")
+@Table(
+        name = "favorite_scenario",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_favorite_scenario_user_scenario", columnNames = {"user_id", "scenario_id"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FavoriteScenario {

--- a/src/main/java/kr/co/mapspring/favorite/repository/FavoritePlaceRepository.java
+++ b/src/main/java/kr/co/mapspring/favorite/repository/FavoritePlaceRepository.java
@@ -3,6 +3,7 @@ package kr.co.mapspring.favorite.repository;
 import kr.co.mapspring.favorite.entity.FavoritePlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Long> {
@@ -10,5 +11,7 @@ public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Lo
     boolean existsByUserIdAndPlaceId(Long userId, Long placeId);
 
     Optional<FavoritePlace> findByUserIdAndPlaceId(Long userId, Long placeId);
+
+    List<FavoritePlace> findAllByUserId(Long userId);
 
 }

--- a/src/main/java/kr/co/mapspring/favorite/repository/FavoritePlaceRepository.java
+++ b/src/main/java/kr/co/mapspring/favorite/repository/FavoritePlaceRepository.java
@@ -1,0 +1,10 @@
+package kr.co.mapspring.favorite.repository;
+
+import kr.co.mapspring.favorite.entity.FavoritePlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Long> {
+
+    boolean existsByUserIdAndPlaceId(Long userId, Long placeId);
+
+}

--- a/src/main/java/kr/co/mapspring/favorite/repository/FavoritePlaceRepository.java
+++ b/src/main/java/kr/co/mapspring/favorite/repository/FavoritePlaceRepository.java
@@ -3,8 +3,12 @@ package kr.co.mapspring.favorite.repository;
 import kr.co.mapspring.favorite.entity.FavoritePlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Long> {
 
     boolean existsByUserIdAndPlaceId(Long userId, Long placeId);
+
+    Optional<FavoritePlace> findByUserIdAndPlaceId(Long userId, Long placeId);
 
 }

--- a/src/main/java/kr/co/mapspring/favorite/repository/FavoriteScenarioRepository.java
+++ b/src/main/java/kr/co/mapspring/favorite/repository/FavoriteScenarioRepository.java
@@ -1,0 +1,16 @@
+package kr.co.mapspring.favorite.repository;
+
+import kr.co.mapspring.favorite.entity.FavoriteScenario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FavoriteScenarioRepository extends JpaRepository<FavoriteScenario, Long> {
+
+    boolean existsByUserIdAndScenarioId(Long userId, Long scenarioId);
+
+    Optional<FavoriteScenario> findByUserIdAndScenarioId(Long userId, Long scenarioId);
+
+    List<FavoriteScenario> findAllByUserId(Long userId);
+}

--- a/src/main/java/kr/co/mapspring/favorite/service/FavoritePlaceService.java
+++ b/src/main/java/kr/co/mapspring/favorite/service/FavoritePlaceService.java
@@ -1,0 +1,14 @@
+package kr.co.mapspring.favorite.service;
+
+public interface FavoritePlaceService {
+    /**
+     * 사용자의 즐겨찾기 장소를 추가한다.
+     *
+     * 동일한 장소는 중복해서 즐겨찾기할 수 없다.
+     *
+     * @param userId 사용자 ID
+     * @param placeId 즐겨찾기할 장소 ID
+     */
+    void addFavoritePlace(Long userId, Long placeId);
+
+}

--- a/src/main/java/kr/co/mapspring/favorite/service/FavoritePlaceService.java
+++ b/src/main/java/kr/co/mapspring/favorite/service/FavoritePlaceService.java
@@ -1,5 +1,9 @@
 package kr.co.mapspring.favorite.service;
 
+import kr.co.mapspring.favorite.entity.FavoritePlace;
+
+import java.util.List;
+
 public interface FavoritePlaceService {
     /**
      * 사용자의 즐겨찾기 장소를 추가한다.
@@ -18,5 +22,13 @@ public interface FavoritePlaceService {
      * @param placeId 삭제할 장소 ID
      */
     void removeFavoritePlace(Long userId, Long placeId);
+
+    /**
+     * 사용자의 즐겨찾기 장소 목록을 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @return 사용자의 즐겨찾기 장소 목록
+     */
+    List<FavoritePlace> getFavoritePlaces(Long userId);
 
 }

--- a/src/main/java/kr/co/mapspring/favorite/service/FavoritePlaceService.java
+++ b/src/main/java/kr/co/mapspring/favorite/service/FavoritePlaceService.java
@@ -11,4 +11,12 @@ public interface FavoritePlaceService {
      */
     void addFavoritePlace(Long userId, Long placeId);
 
+    /**
+     * 사용자의 즐겨찾기 장소를 삭제한다.
+     *
+     * @param userId 사용자 ID
+     * @param placeId 삭제할 장소 ID
+     */
+    void removeFavoritePlace(Long userId, Long placeId);
+
 }

--- a/src/main/java/kr/co/mapspring/favorite/service/FavoriteScenarioService.java
+++ b/src/main/java/kr/co/mapspring/favorite/service/FavoriteScenarioService.java
@@ -1,0 +1,34 @@
+package kr.co.mapspring.favorite.service;
+
+import kr.co.mapspring.favorite.entity.FavoriteScenario;
+
+import java.util.List;
+
+public interface FavoriteScenarioService {
+    /**
+     * 사용자의 즐겨찾기 시나리오를 추가한다.
+     *
+     * 동일한 장소는 중복해서 즐겨찾기할 수 없다.
+     *
+     * @param userId 사용자 ID
+     * @param scenarioId 즐겨찾기할 시나리오 ID
+     */
+    void addFavoriteScenario(Long userId, Long scenarioId);
+
+    /**
+     * 사용자의 즐겨찾기 시나리오를 삭제한다.
+     *
+     * @param userId 사용자 ID
+     * @param scenarioId 삭제할 시나리오 ID
+     */
+    void removeFavoriteScenario(Long userId, Long scenarioId);
+
+    /**
+     * 사용자의 즐겨찾기 시나리오 목록을 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @return 사용자의 즐겨찾기 시나리오 목록
+     */
+    List<FavoriteScenario> getFavoriteScenarios(Long userId);
+
+}

--- a/src/main/java/kr/co/mapspring/favorite/service/impl/FavoritePlaceServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/favorite/service/impl/FavoritePlaceServiceImpl.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -36,5 +38,10 @@ public class FavoritePlaceServiceImpl implements FavoritePlaceService {
                 .orElseThrow(FavoritePlaceNotFoundException::new);
 
         favoritePlaceRepository.delete(favoritePlace);
+    }
+
+    @Override
+    public List<FavoritePlace> getFavoritePlaces(Long userId) {
+        return favoritePlaceRepository.findAllByUserId(userId);
     }
 }

--- a/src/main/java/kr/co/mapspring/favorite/service/impl/FavoritePlaceServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/favorite/service/impl/FavoritePlaceServiceImpl.java
@@ -4,6 +4,7 @@ import kr.co.mapspring.favorite.entity.FavoritePlace;
 import kr.co.mapspring.favorite.repository.FavoritePlaceRepository;
 import kr.co.mapspring.favorite.service.FavoritePlaceService;
 import kr.co.mapspring.global.exception.favorite.FavoritePlaceAlreadyExistsException;
+import kr.co.mapspring.global.exception.favorite.FavoritePlaceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,14 @@ public class FavoritePlaceServiceImpl implements FavoritePlaceService {
 
         FavoritePlace favoritePlace = FavoritePlace.create(userId, placeId);
         favoritePlaceRepository.save(favoritePlace);
+    }
 
+    @Override
+    @Transactional
+    public void removeFavoritePlace(Long userId, Long placeId) {
+        FavoritePlace favoritePlace = favoritePlaceRepository.findByUserIdAndPlaceId(userId, placeId)
+                .orElseThrow(FavoritePlaceNotFoundException::new);
+
+        favoritePlaceRepository.delete(favoritePlace);
     }
 }

--- a/src/main/java/kr/co/mapspring/favorite/service/impl/FavoritePlaceServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/favorite/service/impl/FavoritePlaceServiceImpl.java
@@ -1,0 +1,31 @@
+package kr.co.mapspring.favorite.service.impl;
+
+import kr.co.mapspring.favorite.entity.FavoritePlace;
+import kr.co.mapspring.favorite.repository.FavoritePlaceRepository;
+import kr.co.mapspring.favorite.service.FavoritePlaceService;
+import kr.co.mapspring.global.exception.favorite.FavoritePlaceAlreadyExistsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoritePlaceServiceImpl implements FavoritePlaceService {
+
+    private final FavoritePlaceRepository favoritePlaceRepository;
+
+    @Override
+    @Transactional
+    public void addFavoritePlace(Long userId, Long placeId) {
+        boolean alreadyExists = favoritePlaceRepository.existsByUserIdAndPlaceId(userId, placeId);
+
+        if (alreadyExists) {
+            throw new FavoritePlaceAlreadyExistsException();
+        }
+
+        FavoritePlace favoritePlace = FavoritePlace.create(userId, placeId);
+        favoritePlaceRepository.save(favoritePlace);
+
+    }
+}

--- a/src/main/java/kr/co/mapspring/favorite/service/impl/FavoriteScenarioServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/favorite/service/impl/FavoriteScenarioServiceImpl.java
@@ -1,0 +1,49 @@
+package kr.co.mapspring.favorite.service.impl;
+
+import kr.co.mapspring.favorite.entity.FavoriteScenario;
+import kr.co.mapspring.favorite.repository.FavoriteScenarioRepository;
+import kr.co.mapspring.favorite.service.FavoriteScenarioService;
+import kr.co.mapspring.global.exception.favorite.FavoriteScenarioAlreadyExistsException;
+import kr.co.mapspring.global.exception.favorite.FavoriteScenarioNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoriteScenarioServiceImpl implements FavoriteScenarioService {
+
+    private final FavoriteScenarioRepository favoriteScenarioRepository;
+
+    @Override
+    @Transactional
+    public void addFavoriteScenario(Long userId, Long scenarioId) {
+        boolean alreadyExists =
+                favoriteScenarioRepository.existsByUserIdAndScenarioId(userId, scenarioId);
+
+        if (alreadyExists) {
+            throw new FavoriteScenarioAlreadyExistsException();
+        }
+
+        FavoriteScenario favoriteScenario = FavoriteScenario.create(userId, scenarioId);
+        favoriteScenarioRepository.save(favoriteScenario);
+    }
+
+    @Override
+    @Transactional
+    public void removeFavoriteScenario(Long userId, Long scenarioId) {
+        FavoriteScenario favoriteScenario =
+                favoriteScenarioRepository.findByUserIdAndScenarioId(userId, scenarioId)
+                        .orElseThrow(FavoriteScenarioNotFoundException::new);
+
+        favoriteScenarioRepository.delete(favoriteScenario);
+    }
+
+    @Override
+    public List<FavoriteScenario> getFavoriteScenarios(Long userId) {
+        return favoriteScenarioRepository.findAllByUserId(userId);
+    }
+}

--- a/src/main/java/kr/co/mapspring/global/exception/favorite/FavoritePlaceAlreadyExistsException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/favorite/FavoritePlaceAlreadyExistsException.java
@@ -1,0 +1,6 @@
+package kr.co.mapspring.global.exception.favorite;
+
+public class FavoritePlaceAlreadyExistsException extends RuntimeException {
+
+    public FavoritePlaceAlreadyExistsException() { super("이미 즐겨찾기한 장소입니다."); }
+}

--- a/src/main/java/kr/co/mapspring/global/exception/favorite/FavoritePlaceNotFoundException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/favorite/FavoritePlaceNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.co.mapspring.global.exception.favorite;
+
+public class FavoritePlaceNotFoundException extends RuntimeException {
+
+    public FavoritePlaceNotFoundException() { super("존재하지 않는 즐겨찾기 장소입니다."); }
+
+}

--- a/src/main/java/kr/co/mapspring/global/exception/favorite/FavoriteScenarioAlreadyExistsException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/favorite/FavoriteScenarioAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package kr.co.mapspring.global.exception.favorite;
+
+public class FavoriteScenarioAlreadyExistsException extends RuntimeException {
+
+    public FavoriteScenarioAlreadyExistsException() {
+        super("이미 즐겨찾기한 시나리오입니다.");
+    }
+
+}

--- a/src/main/java/kr/co/mapspring/global/exception/favorite/FavoriteScenarioNotFoundException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/favorite/FavoriteScenarioNotFoundException.java
@@ -1,0 +1,9 @@
+package kr.co.mapspring.global.exception.favorite;
+
+public class FavoriteScenarioNotFoundException extends RuntimeException {
+
+    public FavoriteScenarioNotFoundException() {
+        super("존재하지 않는 즐겨찾기 시나리오입니다.");
+    }
+
+}

--- a/src/main/java/kr/co/mapspring/learning/service/LearningGoalService.java
+++ b/src/main/java/kr/co/mapspring/learning/service/LearningGoalService.java
@@ -1,7 +1,6 @@
 package kr.co.mapspring.learning.service;
 
 public interface LearningGoalService {
-
     /**
      *
      * @param userId

--- a/src/test/java/kr/co/mapspring/favorite/service/FavoritePlaceServiceTest.java
+++ b/src/test/java/kr/co/mapspring/favorite/service/FavoritePlaceServiceTest.java
@@ -4,6 +4,7 @@ import kr.co.mapspring.favorite.entity.FavoritePlace;
 import kr.co.mapspring.favorite.repository.FavoritePlaceRepository;
 import kr.co.mapspring.favorite.service.impl.FavoritePlaceServiceImpl;
 import kr.co.mapspring.global.exception.favorite.FavoritePlaceAlreadyExistsException;
+import kr.co.mapspring.global.exception.favorite.FavoritePlaceNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +12,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -66,5 +69,39 @@ public class FavoritePlaceServiceTest {
 
         verify(favoritePlaceRepository).existsByUserIdAndPlaceId(userId, placeId);
         verify(favoritePlaceRepository, never()).save(any(FavoritePlace.class));
+    }
+
+    @Test
+    @DisplayName("즐겨찾기 장소를 정상적으로 삭제한다")
+    void 즐겨찾기_장소를_정상적으로_삭제한다() {
+
+        Long userId = 1L;
+        Long placeId = 10L;
+        FavoritePlace favoritePlace = FavoritePlace.of(1L, userId, placeId);
+
+        given(favoritePlaceRepository.findByUserIdAndPlaceId(userId, placeId))
+                .willReturn(Optional.of(favoritePlace));
+
+        favoritePlaceService.removeFavoritePlace(userId, placeId);
+
+        verify(favoritePlaceRepository).findByUserIdAndPlaceId(userId, placeId);
+        verify(favoritePlaceRepository).delete(favoritePlace);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 즐겨찾기 장소는 삭제할 수 없다")
+    void 존재하지_않는_즐겨찾기_장소는_삭제할_수_없다() {
+
+        Long userId = 1L;
+        Long placeId = 10L;
+
+        given(favoritePlaceRepository.findByUserIdAndPlaceId(userId, placeId))
+                .willReturn(Optional.empty());
+
+        assertThrows(FavoritePlaceNotFoundException.class,
+                () -> favoritePlaceService.removeFavoritePlace(userId, placeId));
+
+        verify(favoritePlaceRepository).findByUserIdAndPlaceId(userId, placeId);
+        verify(favoritePlaceRepository, never()).delete(any(FavoritePlace.class));
     }
 }

--- a/src/test/java/kr/co/mapspring/favorite/service/FavoritePlaceServiceTest.java
+++ b/src/test/java/kr/co/mapspring/favorite/service/FavoritePlaceServiceTest.java
@@ -1,0 +1,70 @@
+package kr.co.mapspring.favorite.service;
+
+import kr.co.mapspring.favorite.entity.FavoritePlace;
+import kr.co.mapspring.favorite.repository.FavoritePlaceRepository;
+import kr.co.mapspring.favorite.service.impl.FavoritePlaceServiceImpl;
+import kr.co.mapspring.global.exception.favorite.FavoritePlaceAlreadyExistsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class FavoritePlaceServiceTest {
+
+    @Mock
+    private FavoritePlaceRepository favoritePlaceRepository;
+
+    @InjectMocks
+    private FavoritePlaceServiceImpl favoritePlaceService;
+
+    @Test
+    @DisplayName("즐겨찾기 장소를 정상적으로 추가한다")
+    void 즐겨찾기_장소를_정상적으로_추가한다() {
+
+        Long userId = 1L;
+        Long placeId = 10L;
+
+        given(favoritePlaceRepository.existsByUserIdAndPlaceId(userId, placeId))
+                .willReturn(false);
+
+        favoritePlaceService.addFavoritePlace(userId, placeId);
+
+        verify(favoritePlaceRepository).existsByUserIdAndPlaceId(userId, placeId);
+
+        ArgumentCaptor<FavoritePlace> captor = ArgumentCaptor.forClass(FavoritePlace.class);
+        verify(favoritePlaceRepository).save(captor.capture());
+
+        FavoritePlace savedFavoritePlace = captor.getValue();
+        assertEquals(userId, savedFavoritePlace.getUserId());
+        assertEquals(placeId, savedFavoritePlace.getPlaceId());
+
+    }
+
+    @Test
+    @DisplayName("이미 즐겨찾기한 장소는 중복 추가할 수 없다")
+    void 이미_즐겨찾기한_장소는_중복_추가할_수_없다() {
+
+        Long userId = 1L;
+        Long placeId = 10L;
+
+        given(favoritePlaceRepository.existsByUserIdAndPlaceId(userId, placeId))
+                .willReturn(true);
+
+        assertThrows(FavoritePlaceAlreadyExistsException.class,
+                () -> favoritePlaceService.addFavoritePlace(userId, placeId));
+
+        verify(favoritePlaceRepository).existsByUserIdAndPlaceId(userId, placeId);
+        verify(favoritePlaceRepository, never()).save(any(FavoritePlace.class));
+    }
+}

--- a/src/test/java/kr/co/mapspring/favorite/service/FavoritePlaceServiceTest.java
+++ b/src/test/java/kr/co/mapspring/favorite/service/FavoritePlaceServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -103,5 +104,27 @@ public class FavoritePlaceServiceTest {
 
         verify(favoritePlaceRepository).findByUserIdAndPlaceId(userId, placeId);
         verify(favoritePlaceRepository, never()).delete(any(FavoritePlace.class));
+    }
+
+    @Test
+    @DisplayName("사용자의 즐겨찾기 장소 목록을 조회한다")
+    void 사용자의_즐겨찾기_장소_목록을_조회한다() {
+
+        Long userId = 1L;
+
+        FavoritePlace favoritePlace1 = FavoritePlace.of(1L, userId, 10L);
+        FavoritePlace favoritePlace2 = FavoritePlace.of(2L, userId, 20L);
+
+        given(favoritePlaceRepository.findAllByUserId(userId))
+                .willReturn(List.of(favoritePlace1, favoritePlace2));
+
+        List<FavoritePlace> result = favoritePlaceService.getFavoritePlaces(userId);
+
+        verify(favoritePlaceRepository).findAllByUserId(userId);
+        assertEquals(2, result.size());
+        assertEquals(10L, result.get(0).getPlaceId());
+        assertEquals(20L, result.get(1).getPlaceId());
+
+
     }
 }

--- a/src/test/java/kr/co/mapspring/favorite/service/FavoriteScenarioServiceTest.java
+++ b/src/test/java/kr/co/mapspring/favorite/service/FavoriteScenarioServiceTest.java
@@ -1,0 +1,130 @@
+package kr.co.mapspring.favorite.service;
+
+import kr.co.mapspring.favorite.entity.FavoriteScenario;
+import kr.co.mapspring.favorite.repository.FavoriteScenarioRepository;
+import kr.co.mapspring.favorite.service.impl.FavoriteScenarioServiceImpl;
+import kr.co.mapspring.global.exception.favorite.FavoriteScenarioAlreadyExistsException;
+import kr.co.mapspring.global.exception.favorite.FavoriteScenarioNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class FavoriteScenarioServiceTest {
+
+    @Mock
+    private FavoriteScenarioRepository favoriteScenarioRepository;
+
+    @InjectMocks
+    private FavoriteScenarioServiceImpl favoriteScenarioService;
+
+    @Test
+    @DisplayName("즐겨찾기 시나리오를 정상적으로 추가한다")
+    void 즐겨찾기_시나리오를_정상적으로_추가한다() {
+
+        Long userId = 1L;
+        Long scenarioId = 10L;
+
+        given(favoriteScenarioRepository.existsByUserIdAndScenarioId(userId, scenarioId))
+                .willReturn(false);
+
+        favoriteScenarioService.addFavoriteScenario(userId, scenarioId);
+
+        verify(favoriteScenarioRepository).existsByUserIdAndScenarioId(userId, scenarioId);
+
+        ArgumentCaptor<FavoriteScenario> captor = ArgumentCaptor.forClass(FavoriteScenario.class);
+        verify(favoriteScenarioRepository).save(captor.capture());
+
+        FavoriteScenario savedFavoriteScenario = captor.getValue();
+        assertEquals(userId, savedFavoriteScenario.getUserId());
+        assertEquals(scenarioId, savedFavoriteScenario.getScenarioId());
+
+    }
+
+    @Test
+    @DisplayName("이미 즐겨찾기한 시나리오는 중복 추가할 수 없다")
+    void 이미_즐겨찾기한_시나리오는_중복_추가할_수_없다() {
+
+        Long userId = 1L;
+        Long scenarioId = 10L;
+
+        given(favoriteScenarioRepository.existsByUserIdAndScenarioId(userId, scenarioId))
+                .willReturn(true);
+
+        assertThrows(FavoriteScenarioAlreadyExistsException.class,
+                () -> favoriteScenarioService.addFavoriteScenario(userId, scenarioId));
+
+        verify(favoriteScenarioRepository).existsByUserIdAndScenarioId(userId, scenarioId);
+        verify(favoriteScenarioRepository, never()).save(any(FavoriteScenario.class));
+    }
+
+    @Test
+    @DisplayName("즐겨찾기 시나리오를 정상적으로 삭제한다")
+    void 즐겨찾기_시나리오를_정상적으로_삭제한다() {
+
+        Long userId = 1L;
+        Long scenarioId = 10L;
+        FavoriteScenario favoriteScenario = FavoriteScenario.of(1L, userId, scenarioId);
+
+        given(favoriteScenarioRepository.findByUserIdAndScenarioId(userId, scenarioId))
+                .willReturn(Optional.of(favoriteScenario));
+
+        favoriteScenarioService.removeFavoriteScenario(userId, scenarioId);
+
+        verify(favoriteScenarioRepository).findByUserIdAndScenarioId(userId, scenarioId);
+        verify(favoriteScenarioRepository).delete(favoriteScenario);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 즐겨찾기 시나리오는 삭제할 수 없다")
+    void 존재하지_않는_즐겨찾기_시나리오는_삭제할_수_없다() {
+
+        Long userId = 1L;
+        Long scenarioId = 10L;
+
+        given(favoriteScenarioRepository.findByUserIdAndScenarioId(userId, scenarioId))
+                .willReturn(Optional.empty());
+
+        assertThrows(FavoriteScenarioNotFoundException.class,
+                () -> favoriteScenarioService.removeFavoriteScenario(userId, scenarioId));
+
+        verify(favoriteScenarioRepository).findByUserIdAndScenarioId(userId, scenarioId);
+        verify(favoriteScenarioRepository, never()).delete(any(FavoriteScenario.class));
+    }
+
+    @Test
+    @DisplayName("사용자의 즐겨찾기 시나리오 목록을 조회한다")
+    void 사용자의_즐겨찾기_장소_목록을_조회한다() {
+
+        Long userId = 1L;
+
+        FavoriteScenario favoriteScenario1 = FavoriteScenario.of(1L, userId, 10L);
+        FavoriteScenario favoriteScenario2 = FavoriteScenario.of(2L, userId, 20L);
+
+        given(favoriteScenarioRepository.findAllByUserId(userId))
+                .willReturn(List.of(favoriteScenario1, favoriteScenario2));
+
+        List<FavoriteScenario> result = favoriteScenarioService.getFavoriteScenarios(userId);
+
+        verify(favoriteScenarioRepository).findAllByUserId(userId);
+        assertEquals(2, result.size());
+        assertEquals(10L, result.get(0).getScenarioId());
+        assertEquals(20L, result.get(1).getScenarioId());
+
+
+    }
+}


### PR DESCRIPTION
## 작업내용
- 즐겨찾기 기능 구현 (장소, 시나리오)
- TDD 기반 단위 테스트 작성 및 검증


## 변경사항
- FavoritePlace 기능 구현
  - addFavoritePlace (추가)
  - removeFavoritePlace (삭제)
  - getFavoritePlaces (조회)
- FavoriteScenario 기능 구현
  - addFavoriteScenario (추가)
  - removeFavoriteScenario (삭제)
  - getFavoriteScenarios (조회)
- FavoritePlaceService / FavoriteScenarioService 인터페이스 및 구현체 추가
- FavoritePlaceRepository / FavoriteScenarioRepository 메서드 추가
- 예외 처리 클래스 추가
  - FavoritePlaceAlreadyExistsException
  - FavoritePlaceNotFoundException
  - FavoriteScenarioAlreadyExistsException
  - FavoriteScenarioNotFoundException
- 단위 테스트 코드 작성 (Mockito 기반)
  - 추가 / 삭제 / 조회 기능 테스트 및 검증 완료


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [v] 장소 즐겨찾기 추가, 삭제, 조회 테스트 통과
- [v] 시나리오 즐겨찾기 추가, 삭제, 조회 테스트 통과
<img width="375" height="155" alt="image" src="https://github.com/user-attachments/assets/e2bbb544-b47f-4a16-abde-723d56e98ce5" />
<img width="396" height="152" alt="image" src="https://github.com/user-attachments/assets/65373fb4-6917-458e-885f-192fe06ba51b" />


## 참고사항
- User, Place, Scenario 엔티티는 타 도메인 담당으로 ID 기반 설계 적용
- 추후 연관관계(@ManyToOne)로 리팩토링 예정
- 즐겨찾기 기능은 지도학습 페이지에서 API 호출 방식으로 사용 예정

