### PR TITLE
feat(user): 회원가입 기능 1차 서비스 로직 구현 TDD

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -1,7 +1,8 @@
 package kr.co.mapspring.global.exception;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
@@ -15,7 +16,11 @@ public enum ErrorCode {
     //User 로그인용
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    INACTIVE_USER(HttpStatus.FORBIDDEN, "비활성 사용자입니다."),;
+    INACTIVE_USER(HttpStatus.FORBIDDEN, "비활성 사용자입니다."),
+	
+	//User 회원가입용
+	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+	PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
 	
 
     private final HttpStatus status;

--- a/src/main/java/kr/co/mapspring/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/mapspring/global/exception/GlobalExceptionHandler.java
@@ -52,4 +52,18 @@ public class GlobalExceptionHandler {
                         "서버 내부 오류가 발생했습니다."
                 ));
     }
+    
+ // JSON 요청 바인딩 실패 처리
+ // 예: birthDate에 "2000/01/01" 같은 잘못된 날짜 형식이 들어온 경우
+ @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException.class)
+ public ResponseEntity<ApiResponseDTO<Object>> handleHttpMessageNotReadableException(
+         org.springframework.http.converter.HttpMessageNotReadableException e
+ ) {
+	 
+     return ResponseEntity.badRequest()
+             .body(ApiResponseDTO.fail(
+                     org.springframework.http.HttpStatus.BAD_REQUEST,
+                     "요청 데이터 형식이 올바르지 않습니다."
+             ));
+ }
 }

--- a/src/main/java/kr/co/mapspring/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/mapspring/global/exception/GlobalExceptionHandler.java
@@ -1,14 +1,18 @@
 package kr.co.mapspring.global.exception;
 
-import kr.co.mapspring.global.dto.ApiResponseDTO;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.HashMap;
-import java.util.Map;
+import kr.co.mapspring.global.dto.ApiResponseDTO;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -41,6 +45,15 @@ public class GlobalExceptionHandler {
                         errors
                 ));
     }
+    
+    @ExceptionHandler({HttpMessageNotReadableException.class, HttpMessageConversionException.class})
+    public ResponseEntity<ApiResponseDTO<Object>> handleRequestBodyParseException(Exception e) {
+        return ResponseEntity.badRequest()
+                .body(ApiResponseDTO.fail(
+                        HttpStatus.BAD_REQUEST,
+                        "입력값 검증 실패"
+                ));
+    }
 
     // 모든 예외 처리 (최종 fallback)
     @ExceptionHandler(Exception.class)
@@ -52,18 +65,4 @@ public class GlobalExceptionHandler {
                         "서버 내부 오류가 발생했습니다."
                 ));
     }
-    
- // JSON 요청 바인딩 실패 처리
- // 예: birthDate에 "2000/01/01" 같은 잘못된 날짜 형식이 들어온 경우
- @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException.class)
- public ResponseEntity<ApiResponseDTO<Object>> handleHttpMessageNotReadableException(
-         org.springframework.http.converter.HttpMessageNotReadableException e
- ) {
-	 
-     return ResponseEntity.badRequest()
-             .body(ApiResponseDTO.fail(
-                     org.springframework.http.HttpStatus.BAD_REQUEST,
-                     "요청 데이터 형식이 올바르지 않습니다."
-             ));
- }
 }

--- a/src/main/java/kr/co/mapspring/global/exception/user/EmailAlreadyExistsException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/user/EmailAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package kr.co.mapspring.global.exception.user;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class EmailAlreadyExistsException extends CustomException {
+
+    public EmailAlreadyExistsException() {
+        super(ErrorCode.EMAIL_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/kr/co/mapspring/global/exception/user/PasswordConfirmMismatchException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/user/PasswordConfirmMismatchException.java
@@ -1,0 +1,11 @@
+package kr.co.mapspring.global.exception.user;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class PasswordConfirmMismatchException extends CustomException {
+
+    public PasswordConfirmMismatchException() {
+        super(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/controller/AuthController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/AuthController.java
@@ -4,10 +4,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
 
 import kr.co.mapspring.global.dto.ApiResponseDTO;
 import kr.co.mapspring.user.dto.LoginDto;
+import kr.co.mapspring.user.dto.SignUpDto;
 import kr.co.mapspring.user.service.LoginService;
+import kr.co.mapspring.user.service.SignUpService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -16,13 +19,21 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
     private final LoginService loginService;
+    private final SignUpService signUpService;
 
     @PostMapping("/login")
     public ApiResponseDTO<LoginDto.ResponseLogin> login(
             @RequestBody LoginDto.RequestLogin request
     ) {
         LoginDto.ResponseLogin response = loginService.login(request);
-        
         return ApiResponseDTO.success("로그인 성공", response);
+    }
+
+    @PostMapping("/signup")
+    public ApiResponseDTO<SignUpDto.ResponseSignUp> signUp(
+            @Valid @RequestBody SignUpDto.RequestSignUp request
+    ) {
+        SignUpDto.ResponseSignUp response = signUpService.signUp(request);
+        return ApiResponseDTO.success("회원가입 성공", response);
     }
 }

--- a/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
@@ -1,0 +1,64 @@
+package kr.co.mapspring.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.mapspring.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SignUpDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "회원가입 요청 DTO")
+    public static class RequestSignUp {
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        private String name;
+
+        @Schema(description = "생년월일", example = "2000-01-01")
+        private String birthDate;
+
+        @Schema(description = "주소", example = "서울시 강남구")
+        private String address;
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        private String phoneNumber;
+
+        @Schema(description = "이메일", example = "test@naver.com")
+        private String email;
+
+        @Schema(description = "비밀번호", example = "1234")
+        private String password;
+
+        @Schema(description = "비밀번호 확인", example = "1234")
+        private String passwordConfirm;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "회원가입 응답 DTO")
+    public static class ResponseSignUp {
+
+        @Schema(description = "사용자 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "이메일", example = "test@naver.com")
+        private String email;
+
+        @Schema(description = "이름", example = "홍길동")
+        private String name;
+
+        public static ResponseSignUp from(User user) {
+            return ResponseSignUp.builder()
+                    .userId(user.getUserId())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
@@ -1,6 +1,8 @@
 package kr.co.mapspring.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import kr.co.mapspring.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,25 +16,33 @@ public class SignUpDto {
     @NoArgsConstructor
     @Schema(description = "회원가입 요청 DTO")
     public static class RequestSignUp {
-
+    	
+    	@NotBlank
         @Schema(description = "사용자 이름", example = "홍길동")
         private String name;
-
+    	
+    	@NotBlank
         @Schema(description = "생년월일", example = "2000-01-01")
         private String birthDate;
-
+    	
+    	@NotBlank
         @Schema(description = "주소", example = "서울시 강남구")
         private String address;
-
+    	
+    	@NotBlank
         @Schema(description = "전화번호", example = "010-1234-5678")
         private String phoneNumber;
-
+    	
+    	@Email
+    	@NotBlank
         @Schema(description = "이메일", example = "test@naver.com")
         private String email;
-
+    	
+    	@NotBlank
         @Schema(description = "비밀번호", example = "1234")
         private String password;
-
+    	
+    	@NotBlank
         @Schema(description = "비밀번호 확인", example = "1234")
         private String passwordConfirm;
     }

--- a/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
@@ -1,5 +1,7 @@
 package kr.co.mapspring.user.dto;
 
+import java.time.LocalDate;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -23,7 +25,7 @@ public class SignUpDto {
     	
     	@NotBlank
         @Schema(description = "생년월일", example = "2000-01-01")
-        private String birthDate;
+    	private LocalDate birthDate;
     	
     	@NotBlank
         @Schema(description = "주소", example = "서울시 강남구")

--- a/src/main/java/kr/co/mapspring/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/mapspring/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import kr.co.mapspring.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+    
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/kr/co/mapspring/user/service/SignUpService.java
+++ b/src/main/java/kr/co/mapspring/user/service/SignUpService.java
@@ -1,0 +1,9 @@
+package kr.co.mapspring.user.service;
+
+import kr.co.mapspring.user.dto.SignUpDto;
+
+public interface SignUpService {
+	
+    SignUpDto.ResponseSignUp signUp(SignUpDto.RequestSignUp request);
+
+}

--- a/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
@@ -1,9 +1,8 @@
 package kr.co.mapspring.user.service.impl;
 
-import java.time.LocalDate;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import kr.co.mapspring.global.exception.user.EmailAlreadyExistsException;
 import kr.co.mapspring.global.exception.user.PasswordConfirmMismatchException;
@@ -22,6 +21,7 @@ public class SignUpServiceImpl implements SignUpService {
     private final PasswordEncoder passwordEncoder;
 
     @Override
+    @Transactional
     public SignUpDto.ResponseSignUp signUp(SignUpDto.RequestSignUp request) {
         if (userRepository.existsByEmail(request.getEmail())) {
         	throw new EmailAlreadyExistsException();
@@ -33,12 +33,11 @@ public class SignUpServiceImpl implements SignUpService {
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        LocalDate birthDate = LocalDate.parse(request.getBirthDate());
 
         User user = User.create(
                 request.getEmail(),
                 request.getName(), 	
-                birthDate,
+                request.getBirthDate(),
                 request.getAddress(),
                 request.getPhoneNumber(),
                 encodedPassword

--- a/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
@@ -1,6 +1,11 @@
 package kr.co.mapspring.user.service.impl;
 
+import java.time.LocalDate;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
 import kr.co.mapspring.user.dto.SignUpDto;
+import kr.co.mapspring.user.entity.User;
 import kr.co.mapspring.user.repository.UserRepository;
 import kr.co.mapspring.user.service.SignUpService;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +22,29 @@ public class SignUpServiceImpl implements SignUpService {
 
     @Override
     public SignUpDto.ResponseSignUp signUp(SignUpDto.RequestSignUp request) {
-        return null;
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.DUPLICATE_RESOURCE, "이미 존재하는 이메일입니다.");
+        }
+
+        if (!request.getPassword().equals(request.getPasswordConfirm())) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        LocalDate birthDate = LocalDate.parse(request.getBirthDate());
+
+        User user = User.create(
+                request.getEmail(),
+                request.getName(), 	
+                birthDate,
+                request.getAddress(),
+                request.getPhoneNumber(),
+                encodedPassword
+        );
+
+        User savedUser = userRepository.save(user);
+
+        return SignUpDto.ResponseSignUp.from(savedUser);
     }
 }

--- a/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
@@ -1,0 +1,22 @@
+package kr.co.mapspring.user.service.impl;
+
+import kr.co.mapspring.user.dto.SignUpDto;
+import kr.co.mapspring.user.repository.UserRepository;
+import kr.co.mapspring.user.service.SignUpService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpServiceImpl implements SignUpService {
+
+    private final UserRepository userRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public SignUpDto.ResponseSignUp signUp(SignUpDto.RequestSignUp request) {
+        return null;
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
@@ -2,15 +2,16 @@ package kr.co.mapspring.user.service.impl;
 
 import java.time.LocalDate;
 
-import kr.co.mapspring.global.exception.CustomException;
-import kr.co.mapspring.global.exception.ErrorCode;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import kr.co.mapspring.global.exception.user.EmailAlreadyExistsException;
+import kr.co.mapspring.global.exception.user.PasswordConfirmMismatchException;
 import kr.co.mapspring.user.dto.SignUpDto;
 import kr.co.mapspring.user.entity.User;
 import kr.co.mapspring.user.repository.UserRepository;
 import kr.co.mapspring.user.service.SignUpService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -23,11 +24,11 @@ public class SignUpServiceImpl implements SignUpService {
     @Override
     public SignUpDto.ResponseSignUp signUp(SignUpDto.RequestSignUp request) {
         if (userRepository.existsByEmail(request.getEmail())) {
-            throw new CustomException(ErrorCode.DUPLICATE_RESOURCE, "이미 존재하는 이메일입니다.");
+        	throw new EmailAlreadyExistsException();
         }
 
         if (!request.getPassword().equals(request.getPasswordConfirm())) {
-            throw new CustomException(ErrorCode.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+        	throw new PasswordConfirmMismatchException();
         }
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -157,4 +157,32 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(403))
                 .andExpect(jsonPath("$.message").value("비활성 사용자입니다."));
     }
+    
+    @Test
+    @DisplayName("생년월일 형식이 올바르지 않으면 400 실패 응답을 반환한다")
+    void signUpFailWhenBirthDateFormatIsInvalid() throws Exception {
+        // given
+        String requestBody = """
+                {
+                  "name": "홍길동",
+                  "birthDate": "2000/01/01",
+                  "address": "서울시 강남구",
+                  "phoneNumber": "010-1234-5678",
+                  "email": "test@naver.com",
+                  "password": "1234",
+                  "passwordConfirm": "1234"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message")
+                        .value("생년월일 형식이 올바르지 않습니다. yyyy-MM-dd 형식으로 입력해주세요."));
+    }
+    
 }

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -21,26 +21,26 @@ import kr.co.mapspring.global.exception.ErrorCode;
 import kr.co.mapspring.global.exception.GlobalExceptionHandler;
 import kr.co.mapspring.user.dto.LoginDto;
 import kr.co.mapspring.user.service.LoginService;
+import kr.co.mapspring.user.service.SignUpService;
 
 @WebMvcTest(AuthController.class)
-// Security filter 때문에 401/403이 뜨면 이 설정이 도움이 된다.
 @AutoConfigureMockMvc(addFilters = false)
-// 전역 예외 처리기도 같이 테스트에 포함시킨다.
 @Import(GlobalExceptionHandler.class)
 class AuthControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    // 컨트롤러가 의존하는 서비스는 mock으로 대체한다.
     @MockitoBean
     private LoginService loginService;
+
+    @MockitoBean
+    private SignUpService signUpService;
 
     @Test
     @DisplayName("로그인 요청이 성공하면 공통 성공 응답을 반환한다")
     void loginSuccess() throws Exception {
         // given
-        // 서비스가 정상 로그인 결과를 반환한다고 가정한다.
         LoginDto.ResponseLogin response = LoginDto.ResponseLogin.builder()
                 .userId(1L)
                 .email("test@naver.com")
@@ -48,11 +48,9 @@ class AuthControllerTest {
                 .role("USER")
                 .build();
 
-        // 어떤 로그인 요청이 오든 위 응답을 반환하도록 mock 설정
         given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
                 .willReturn(response);
 
-        // 실제 요청 body 역할을 하는 JSON 문자열
         String requestBody = """
                 {
                   "email": "test@naver.com",
@@ -62,17 +60,12 @@ class AuthControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/login")
-                        // 요청 데이터가 JSON임을 명시
                         .contentType(APPLICATION_JSON)
-                        // 요청 body 삽입
                         .content(requestBody))
-                // HTTP 상태코드 200 확인
                 .andExpect(status().isOk())
-                // 공통 응답 구조 확인
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("로그인 성공"))
-                // 실제 data 값 확인
                 .andExpect(jsonPath("$.data.userId").value(1))
                 .andExpect(jsonPath("$.data.email").value("test@naver.com"))
                 .andExpect(jsonPath("$.data.name").value("홍길동"))
@@ -83,7 +76,6 @@ class AuthControllerTest {
     @DisplayName("존재하지 않는 이메일이면 404 실패 응답을 반환한다")
     void loginFailWhenUserNotFound() throws Exception {
         // given
-        // 서비스가 USER_NOT_FOUND 예외를 던진다고 가정한다.
         given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
                 .willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -98,9 +90,7 @@ class AuthControllerTest {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(APPLICATION_JSON)
                         .content(requestBody))
-                // USER_NOT_FOUND는 ErrorCode 기준 404
                 .andExpect(status().isNotFound())
-                // 공통 실패 응답 구조 확인
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.message").value("존재하지 않는 이메일입니다."));
@@ -110,7 +100,6 @@ class AuthControllerTest {
     @DisplayName("비밀번호가 일치하지 않으면 401 실패 응답을 반환한다")
     void loginFailWhenPasswordInvalid() throws Exception {
         // given
-        // 서비스가 INVALID_PASSWORD 예외를 던진다고 가정한다.
         given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
                 .willThrow(new CustomException(ErrorCode.INVALID_PASSWORD));
 
@@ -125,7 +114,6 @@ class AuthControllerTest {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(APPLICATION_JSON)
                         .content(requestBody))
-                // INVALID_PASSWORD는 ErrorCode 기준 401
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.status").value(401))
@@ -136,7 +124,6 @@ class AuthControllerTest {
     @DisplayName("사용자 상태가 ACTIVE가 아니면 403 실패 응답을 반환한다")
     void loginFailWhenInactiveUser() throws Exception {
         // given
-        // 서비스가 INACTIVE_USER 예외를 던진다고 가정한다.
         given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
                 .willThrow(new CustomException(ErrorCode.INACTIVE_USER));
 
@@ -151,13 +138,12 @@ class AuthControllerTest {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(APPLICATION_JSON)
                         .content(requestBody))
-                // INACTIVE_USER는 ErrorCode 기준 403
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.status").value(403))
                 .andExpect(jsonPath("$.message").value("비활성 사용자입니다."));
     }
-    
+
     @Test
     @DisplayName("생년월일 형식이 올바르지 않으면 400 실패 응답을 반환한다")
     void signUpFailWhenBirthDateFormatIsInvalid() throws Exception {
@@ -181,8 +167,6 @@ class AuthControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.message")
-                        .value("생년월일 형식이 올바르지 않습니다. yyyy-MM-dd 형식으로 입력해주세요."));
+                .andExpect(jsonPath("$.message").value("입력값 검증 실패"));
     }
-    
 }

--- a/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
@@ -43,7 +43,7 @@ class SignUpServiceTest {
         // 회원가입 요청 객체를 만든다.
         SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
                 "홍길동",
-                "2000-01-01",
+                LocalDate.of(2000, 1, 1),
                 "서울시 강남구",
                 "010-1234-5678",
                 "test@naver.com",
@@ -93,7 +93,7 @@ class SignUpServiceTest {
         // 이미 가입된 이메일로 회원가입 요청을 만든다.
         SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
                 "홍길동",
-                "2000-01-01",
+                LocalDate.of(2000, 1, 1),
                 "서울시 강남구",
                 "010-1234-5678",
                 "test@naver.com",
@@ -120,7 +120,7 @@ class SignUpServiceTest {
         // 비밀번호와 비밀번호 확인값이 서로 다른 회원가입 요청을 만든다.
         SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
                 "홍길동",
-                "2000-01-01",
+                LocalDate.of(2000, 1, 1),
                 "서울시 강남구",
                 "010-1234-5678",
                 "test@naver.com",
@@ -146,7 +146,7 @@ class SignUpServiceTest {
         // given
         SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
                 "홍길동",
-                "2000-01-01",
+                LocalDate.of(2000, 1, 1),
                 "서울시 강남구",
                 "010-1234-5678",
                 "test@naver.com",
@@ -195,7 +195,7 @@ class SignUpServiceTest {
         // given
         SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
                 "홍길동",
-                "2000-01-01",
+                LocalDate.of(2000, 1, 1),
                 "서울시 강남구",
                 "010-1234-5678",
                 "test@naver.com",
@@ -238,4 +238,6 @@ class SignUpServiceTest {
         assertThat(capturedUser.getRole())
                 .isEqualTo(kr.co.mapspring.user.enums.UserRole.USER);
     }
+    
+    
 }

--- a/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
@@ -1,0 +1,83 @@
+package kr.co.mapspring.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+
+import kr.co.mapspring.user.dto.SignUpDto;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.enums.UserRole;
+import kr.co.mapspring.user.enums.UserStatus;
+import kr.co.mapspring.user.repository.UserRepository;
+import kr.co.mapspring.user.service.impl.SignUpServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class SignUpServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private SignUpServiceImpl signUpService;
+
+    @Test
+    @DisplayName("중복되지 않은 이메일이면 회원가입에 성공한다")
+    void signUpSuccess() {
+        // given
+        // 회원가입 요청 객체를 만든다.
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                "2000-01-01",
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "1234"
+        );
+
+        // 해당 이메일이 아직 존재하지 않는다고 가정한다.
+        given(userRepository.existsByEmail("test@naver.com"))
+                .willReturn(false);
+
+        // 비밀번호 암호화 결과를 가정한다.
+        given(passwordEncoder.encode("1234"))
+                .willReturn("encodedPassword");
+
+        // 저장 후 반환될 User 객체를 만든다.
+        User savedUser = User.builder()
+                .userId(1L)
+                .email("test@naver.com")
+                .name("홍길동")
+                .birthDate(LocalDate.of(2000, 1, 1))
+                .address("서울시 강남구")
+                .phoneNumber("010-1234-5678")
+                .passwordHash("encodedPassword")
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+
+        // save 호출 시 위 객체를 반환한다고 가정한다.
+        given(userRepository.save(org.mockito.ArgumentMatchers.any(User.class)))
+                .willReturn(savedUser);
+
+        // when
+        SignUpDto.ResponseSignUp response = signUpService.signUp(request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUserId()).isEqualTo(1L);
+        assertThat(response.getEmail()).isEqualTo("test@naver.com");
+        assertThat(response.getName()).isEqualTo("홍길동");
+    }
+}

--- a/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
@@ -1,23 +1,28 @@
 package kr.co.mapspring.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import kr.co.mapspring.global.exception.CustomException;
 import kr.co.mapspring.user.dto.SignUpDto;
 import kr.co.mapspring.user.entity.User;
 import kr.co.mapspring.user.enums.UserRole;
 import kr.co.mapspring.user.enums.UserStatus;
 import kr.co.mapspring.user.repository.UserRepository;
 import kr.co.mapspring.user.service.impl.SignUpServiceImpl;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 class SignUpServiceTest {
@@ -79,5 +84,158 @@ class SignUpServiceTest {
         assertThat(response.getUserId()).isEqualTo(1L);
         assertThat(response.getEmail()).isEqualTo("test@naver.com");
         assertThat(response.getName()).isEqualTo("홍길동");
+    }
+    
+    @Test
+    @DisplayName("이미 존재하는 이메일이면 예외가 발생한다")
+    void signUpFailWhenEmailAlreadyExists() {
+        // given
+        // 이미 가입된 이메일로 회원가입 요청을 만든다.
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                "2000-01-01",
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "1234"
+        );
+
+        // 해당 이메일이 이미 존재한다고 가정한다.
+        given(userRepository.existsByEmail("test@naver.com"))
+                .willReturn(true);
+
+        // when & then
+        // 회원가입 시 CustomException이 발생하고,
+        // 메시지가 "이미 존재하는 이메일입니다."인지 확인한다.
+        assertThatThrownBy(() -> signUpService.signUp(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 존재하는 이메일입니다.");
+    }
+    
+    @Test
+    @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 예외가 발생한다")
+    void signUpFailWhenPasswordConfirmDoesNotMatch() {
+        // given
+        // 비밀번호와 비밀번호 확인값이 서로 다른 회원가입 요청을 만든다.
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                "2000-01-01",
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "4321"
+        );
+
+        // 이메일은 중복되지 않는다고 가정한다.
+        given(userRepository.existsByEmail("test@naver.com"))
+                .willReturn(false);
+
+        // when & then
+        // 회원가입 시 CustomException이 발생하고,
+        // 메시지가 비밀번호 불일치 메시지인지 확인한다.
+        assertThatThrownBy(() -> signUpService.signUp(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+    }
+    
+    @Test
+    @DisplayName("회원가입 시 비밀번호는 암호화되어 저장된다")
+    void signUpPasswordShouldBeEncodedBeforeSave() {
+        // given
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                "2000-01-01",
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "1234"
+        );
+
+        given(userRepository.existsByEmail("test@naver.com"))
+                .willReturn(false);
+
+        given(passwordEncoder.encode("1234"))
+                .willReturn("encodedPassword");
+
+        User savedUser = User.builder()
+                .userId(1L)
+                .email("test@naver.com")
+                .name("홍길동")
+                .birthDate(java.time.LocalDate.of(2000, 1, 1))
+                .address("서울시 강남구")
+                .phoneNumber("010-1234-5678")
+                .passwordHash("encodedPassword")
+                .status(kr.co.mapspring.user.enums.UserStatus.ACTIVE)
+                .role(kr.co.mapspring.user.enums.UserRole.USER)
+                .build();
+
+        given(userRepository.save(org.mockito.ArgumentMatchers.any(User.class)))
+                .willReturn(savedUser);
+
+        // when
+        signUpService.signUp(request);
+
+        // then
+        // save에 실제로 전달된 User 객체를 캡처한다.
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+
+        User capturedUser = userCaptor.getValue();
+
+        // 저장 직전 User의 비밀번호가 평문이 아닌 암호화값인지 확인
+        assertThat(capturedUser.getPasswordHash()).isEqualTo("encodedPassword");
+    }
+    
+    @Test
+    @DisplayName("회원가입 시 기본 상태는 ACTIVE이고 권한은 USER다")
+    void signUpShouldSaveDefaultStatusAndRole() {
+        // given
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                "2000-01-01",
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "1234"
+        );
+
+        given(userRepository.existsByEmail("test@naver.com"))
+                .willReturn(false);
+
+        given(passwordEncoder.encode("1234"))
+                .willReturn("encodedPassword");
+
+        User savedUser = User.builder()
+                .userId(1L)
+                .email("test@naver.com")
+                .name("홍길동")
+                .birthDate(java.time.LocalDate.of(2000, 1, 1))
+                .address("서울시 강남구")
+                .phoneNumber("010-1234-5678")
+                .passwordHash("encodedPassword")
+                .status(kr.co.mapspring.user.enums.UserStatus.ACTIVE)
+                .role(kr.co.mapspring.user.enums.UserRole.USER)
+                .build();
+
+        given(userRepository.save(org.mockito.ArgumentMatchers.any(User.class)))
+                .willReturn(savedUser);
+
+        // when
+        signUpService.signUp(request);
+
+        // then
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+
+        User capturedUser = userCaptor.getValue();
+
+        assertThat(capturedUser.getStatus())
+                .isEqualTo(kr.co.mapspring.user.enums.UserStatus.ACTIVE);
+        assertThat(capturedUser.getRole())
+                .isEqualTo(kr.co.mapspring.user.enums.UserRole.USER);
     }
 }


### PR DESCRIPTION
## 작업내용

- 회원가입 기능 1차 서비스 로직 구현
- 회원가입 성공/실패 시나리오에 대한 단위 테스트 작성
- 회원가입시 예외 처리 적용

## 변경사항

- SignUpDto 추가
- 회원가입 관련 커스텀 예외 (PasswordConfirmMismatchException, EmailAlreadyExistsException) 추가
- 회원가입 서비스 테스트 추가

회원가입 성공
중복 이메일 예외
비밀번호 확인 불일치 예외

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="470" height="148" alt="image" src="https://github.com/user-attachments/assets/f714705b-7882-48ad-a974-d310c7f2a7fc" />



## 참고사항

- 현재 범위는 회원가입 1차 서비스 구현 및 단위 테스트까지 진행

- 약관 동의 기능은 회원가입 화면/ERD에는 포함되어 있으나, 현재 푸쉬 범위에서는 제외하고 유저 생성 흐름만 먼저 구현

- 신규 사용자 생성 시의 기본 규칙은 User.create(...) 내부에 두었습니다.
EX
기본 상태 ACTIVE
기본 권한 USER
즉 User 자신의 생성 규칙/상태 규칙은 엔티티가 책임지도록 유지했습니다.

- User.create(...) 호출을 서비스에 둔 이유
User.create(...) 자체는 엔티티 생성 규칙을 담고 있으므로 도메인 규칙에 해당합니다
다만 그 생성 규칙을 회원가입 유스케이스 안에서 언제 호출할지 조합하는 책임은 서비스에 있다고 보여지고
User.create(...) 내부 = 엔티티 규칙
서비스에서 User.create(...) 호출 = 회원가입 흐름 조합
으로 역할을 구분해보았습니다