### PR TITLE
feat(user): 회원가입 기능 완료 및 Swaager 문서화 작업 완료

### DIFF
--- a/src/main/java/kr/co/mapspring/user/controller/AuthController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/AuthController.java
@@ -1,10 +1,5 @@
 package kr.co.mapspring.user.controller;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import kr.co.mapspring.global.dto.ApiResponseDTO;
 import kr.co.mapspring.user.controller.docs.AuthControllerDocs;
 import kr.co.mapspring.user.dto.LoginDto;
@@ -12,6 +7,7 @@ import kr.co.mapspring.user.dto.SignUpDto;
 import kr.co.mapspring.user.service.LoginService;
 import kr.co.mapspring.user.service.SignUpService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")

--- a/src/main/java/kr/co/mapspring/user/controller/AuthController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/AuthController.java
@@ -4,9 +4,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import jakarta.validation.Valid;
 
 import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.user.controller.docs.AuthControllerDocs;
 import kr.co.mapspring.user.dto.LoginDto;
 import kr.co.mapspring.user.dto.SignUpDto;
 import kr.co.mapspring.user.service.LoginService;
@@ -16,24 +16,35 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
 
+    // 로그인 서비스
     private final LoginService loginService;
+
+    // 회원가입 서비스
     private final SignUpService signUpService;
 
+    @Override
     @PostMapping("/login")
     public ApiResponseDTO<LoginDto.ResponseLogin> login(
             @RequestBody LoginDto.RequestLogin request
     ) {
+        // 로그인 서비스 호출
         LoginDto.ResponseLogin response = loginService.login(request);
+
+        // 공통 성공 응답 반환
         return ApiResponseDTO.success("로그인 성공", response);
     }
 
+    @Override
     @PostMapping("/signup")
     public ApiResponseDTO<SignUpDto.ResponseSignUp> signUp(
-            @Valid @RequestBody SignUpDto.RequestSignUp request
+            @RequestBody SignUpDto.RequestSignUp request
     ) {
+        // 회원가입 서비스 호출
         SignUpDto.ResponseSignUp response = signUpService.signUp(request);
+
+        // 공통 성공 응답 반환
         return ApiResponseDTO.success("회원가입 성공", response);
     }
 }

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.mapspring.global.dto.ApiResponseDTO;
 import kr.co.mapspring.user.dto.LoginDto;
+import kr.co.mapspring.user.dto.SignUpDto;
 
 @Tag(name = "Auth", description = "인증 관련 API")
 public interface AuthControllerDocs {
@@ -19,17 +20,13 @@ public interface AuthControllerDocs {
             description = "이메일과 비밀번호를 입력받아 로그인 처리하고 사용자 정보를 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "로그인 성공"
-            ),
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(
                     responseCode = "404",
                     description = "존재하지 않는 이메일",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "USER_NOT_FOUND",
                                     value = """
                                             {
                                               "success": false,
@@ -47,7 +44,6 @@ public interface AuthControllerDocs {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "INVALID_PASSWORD",
                                     value = """
                                             {
                                               "success": false,
@@ -65,7 +61,6 @@ public interface AuthControllerDocs {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "INACTIVE_USER",
                                     value = """
                                             {
                                               "success": false,
@@ -86,7 +81,6 @@ public interface AuthControllerDocs {
                             mediaType = "application/json",
                             schema = @Schema(implementation = LoginDto.RequestLogin.class),
                             examples = @ExampleObject(
-                                    name = "로그인 요청 예시",
                                     value = """
                                             {
                                               "email": "test@naver.com",
@@ -97,5 +91,71 @@ public interface AuthControllerDocs {
                     )
             )
             LoginDto.RequestLogin request
+    );
+
+    @Operation(
+            summary = "회원가입",
+            description = "이름, 생년월일, 주소, 전화번호, 이메일, 비밀번호를 입력받아 회원가입을 처리합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 존재하는 이메일",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 409,
+                                              "message": "이미 존재하는 이메일입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "비밀번호 확인 불일치",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponseDTO<SignUpDto.ResponseSignUp> signUp(
+            @RequestBody(
+                    description = "회원가입 요청 정보",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SignUpDto.RequestSignUp.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "name": "홍길동",
+                                              "birthDate": "2000-01-01",
+                                              "address": "서울시 강남구",
+                                              "phoneNumber": "010-1234-5678",
+                                              "email": "test@naver.com",
+                                              "password": "1234",
+                                              "passwordConfirm": "1234"
+                                            }
+                                            """
+                            )
+                    )
+            )
+            SignUpDto.RequestSignUp request
     );
 }

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
@@ -92,7 +92,7 @@ public interface AuthControllerDocs {
             )
             LoginDto.RequestLogin request
     );
-
+    
     @Operation(
             summary = "회원가입",
             description = "이름, 생년월일, 주소, 전화번호, 이메일, 비밀번호를 입력받아 회원가입을 처리합니다."

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -20,6 +20,7 @@ import kr.co.mapspring.global.exception.CustomException;
 import kr.co.mapspring.global.exception.ErrorCode;
 import kr.co.mapspring.global.exception.GlobalExceptionHandler;
 import kr.co.mapspring.user.dto.LoginDto;
+import kr.co.mapspring.user.dto.SignUpDto;
 import kr.co.mapspring.user.service.LoginService;
 import kr.co.mapspring.user.service.SignUpService;
 
@@ -169,4 +170,103 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("입력값 검증 실패"));
     }
+    @Test
+    @DisplayName("회원가입 요청이 성공하면 공통 성공 응답을 반환한다")
+    void signUpSuccess() throws Exception {
+        // given
+        SignUpDto.ResponseSignUp response = SignUpDto.ResponseSignUp.builder()
+                .userId(1L)
+                .email("test@naver.com")
+                .name("홍길동")
+                .build();
+
+        // 회원가입 서비스가 성공 응답을 반환한다고 가정한다.
+        given(signUpService.signUp(org.mockito.ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+                .willReturn(response);
+
+        String requestBody = """
+                {
+                  "name": "홍길동",
+                  "birthDate": "2000-01-01",
+                  "address": "서울시 강남구",
+                  "phoneNumber": "010-1234-5678",
+                  "email": "test@naver.com",
+                  "password": "1234",
+                  "passwordConfirm": "1234"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("회원가입 성공"))
+                .andExpect(jsonPath("$.data.userId").value(1))
+                .andExpect(jsonPath("$.data.email").value("test@naver.com"))
+                .andExpect(jsonPath("$.data.name").value("홍길동"));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 이메일이면 409 실패 응답을 반환한다")
+    void signUpFailWhenEmailAlreadyExists() throws Exception {
+        // given
+        given(signUpService.signUp(org.mockito.ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+                .willThrow(new kr.co.mapspring.global.exception.user.EmailAlreadyExistsException());
+
+        String requestBody = """
+                {
+                  "name": "홍길동",
+                  "birthDate": "2000-01-01",
+                  "address": "서울시 강남구",
+                  "phoneNumber": "010-1234-5678",
+                  "email": "test@naver.com",
+                  "password": "1234",
+                  "passwordConfirm": "1234"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("이미 존재하는 이메일입니다."));
+    }
+
+    @Test
+    @DisplayName("비밀번호 확인이 일치하지 않으면 400 실패 응답을 반환한다")
+    void signUpFailWhenPasswordConfirmDoesNotMatch() throws Exception {
+        // given
+        given(signUpService.signUp(org.mockito.ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+                .willThrow(new kr.co.mapspring.global.exception.user.PasswordConfirmMismatchException());
+
+        String requestBody = """
+                {
+                  "name": "홍길동",
+                  "birthDate": "2000-01-01",
+                  "address": "서울시 강남구",
+                  "phoneNumber": "010-1234-5678",
+                  "email": "test@naver.com",
+                  "password": "1234",
+                  "passwordConfirm": "4321"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("비밀번호와 비밀번호 확인이 일치하지 않습니다."));
+    }
+    
+    
+    
 }


### PR DESCRIPTION
## 작업내용

- 회원가입 기능 서비스 로직 구현 완료
- 회원가입시 응답/ 응답 실패 시나리오 대한 단위 테스트 작성

## 변경사항

- Swagger 문서화 및 Controller docs 회원가입 관련 설명 추가 
- AuthController 회원가입 (signup) 메서드 추가

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="977" height="112" alt="image" src="https://github.com/user-attachments/assets/91510888-7d28-4fbb-b6d7-388aabd3429a" />
<img width="1050" height="716" alt="image" src="https://github.com/user-attachments/assets/870b59f9-70fb-4f1b-90cb-57bb48d66049" />
기존 더미데이터 값에 들어가있는 "test@naver.com" 이메일로 회원가입시 예외처리 확인 완료
<img width="1118" height="779" alt="image" src="https://github.com/user-attachments/assets/2a6c7f58-3fab-44db-aedb-dcd7554e4782" />



## 참고사항

- Swaager 테스트 완료      
- 