### PR TITLE
fix(favorite): Swagger @RequestParam 파라미터명 arg0 노출 문제 해결

### DIFF
--- a/src/main/java/kr/co/mapspring/favorite/controller/FavoriteScenarioController.java
+++ b/src/main/java/kr/co/mapspring/favorite/controller/FavoriteScenarioController.java
@@ -40,7 +40,7 @@ public class FavoriteScenarioController implements FavoriteScenarioControllerDoc
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponseDTO<List<FavoriteScenarioDto.ResponseFavoriteScenario>>> getFavoriteScenarios(@RequestParam Long userId) {
+    public ResponseEntity<ApiResponseDTO<List<FavoriteScenarioDto.ResponseFavoriteScenario>>> getFavoriteScenarios(@RequestParam("userId") Long userId) {
         List<FavoriteScenarioDto.ResponseFavoriteScenario> result =
                 favoriteScenarioService.getFavoriteScenarios(userId)
                         .stream()


### PR DESCRIPTION
## 작업내용
- Swagger에서 @RequestParam 파라미터명이 arg0로 표시되는 문제 수정
- fixes #38 

## 변경사항
- @RequestParam에 명시적으로 파라미터명 지정 (userId)
- Swagger에서 query parameter가 정상적으로 userId로 표시되도록 수정

## 테스트 결과
- [v] Swagger에서 userId 정상 표시 확인
- [v] 즐겨찾기 조회 API 정상 동작 확인
<img width="397" height="264" alt="image" src="https://github.com/user-attachments/assets/bc62cc05-df4d-461b-bd8c-2891ca4e10fc" />
<img width="450" height="221" alt="image" src="https://github.com/user-attachments/assets/3f8e7f64-2ffd-4135-84ff-15f38148c867" />


## 참고사항
- 컴파일 시 파라미터명 유지 옵션(-parameters) 없이도 동작하도록 명시적 이름 지정

