### PR TITLE
feat(learning): 학습 목표 및 학습 기록 기능 구현

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -28,7 +28,13 @@ public enum ErrorCode {
 
     // Favorite Scenario
     FAVORITE_SCENARIO_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기한 시나리오입니다."),
-    FAVORITE_SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 즐겨찾기 시나리오입니다.");
+    FAVORITE_SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 즐겨찾기 시나리오입니다."),
+
+    // Learning Goal
+    GOAL_MASTER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 학습 목표입니다."),
+    GOAL_ALREADY_SELECTED(HttpStatus.CONFLICT, "이미 선택한 학습 목표입니다."),
+    GOAL_SELECTION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "학습 목표는 최대 3개까지만 선택할 수 있습니다."),
+    USER_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 목표입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/kr/co/mapspring/learning/controller/LearningController.java
+++ b/src/main/java/kr/co/mapspring/learning/controller/LearningController.java
@@ -1,0 +1,29 @@
+package kr.co.mapspring.learning.controller;
+
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.learning.controller.docs.LearningControllerDocs;
+import kr.co.mapspring.learning.dto.LearningLogDto;
+import kr.co.mapspring.learning.service.LearningService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/learning")
+@RequiredArgsConstructor
+public class LearningController implements LearningControllerDocs {
+
+    private LearningService learningService;
+
+    @GetMapping("logs")
+    public ResponseEntity<ApiResponseDTO<List<LearningLogDto.ResponseLog>>> getStudyLogs(@RequestParam("userId") Long userId) {
+        List<LearningLogDto.ResponseLog> result = learningService.getStudyLogs(userId);
+
+        return ResponseEntity.ok(ApiResponseDTO.success("학습 기록 조회 성공", result));
+    }
+}

--- a/src/main/java/kr/co/mapspring/learning/controller/LearningController.java
+++ b/src/main/java/kr/co/mapspring/learning/controller/LearningController.java
@@ -20,7 +20,7 @@ public class LearningController implements LearningControllerDocs {
 
     private LearningService learningService;
 
-    @GetMapping("logs")
+    @GetMapping("/logs")
     public ResponseEntity<ApiResponseDTO<List<LearningLogDto.ResponseLog>>> getStudyLogs(@RequestParam("userId") Long userId) {
         List<LearningLogDto.ResponseLog> result = learningService.getStudyLogs(userId);
 

--- a/src/main/java/kr/co/mapspring/learning/controller/LearningGoalController.java
+++ b/src/main/java/kr/co/mapspring/learning/controller/LearningGoalController.java
@@ -1,0 +1,69 @@
+package kr.co.mapspring.learning.controller;
+
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.learning.dto.LearningGoalDto;
+import kr.co.mapspring.learning.entity.GoalMaster;
+import kr.co.mapspring.learning.entity.UserGoal;
+import kr.co.mapspring.learning.service.LearningGoalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/learning/goals")
+@RequiredArgsConstructor
+public class LearningGoalController {
+
+    private final LearningGoalService learningGoalService;
+
+    @PostMapping
+    public ApiResponseDTO<Void> selectGoal(@RequestBody LearningGoalDto.RequestSelectGoal request) {
+        learningGoalService.selectGoal(
+                request.getUserId(),
+                request.getGoalMasterId()
+        );
+
+        return ApiResponseDTO.success("학습 목표 선택 성공");
+    }
+
+    @DeleteMapping("/{userGoalId}")
+    public ApiResponseDTO<Void> calcelGoal(@PathVariable("userGoalId") Long userGoalId) {
+        learningGoalService.cancelGoal(userGoalId);
+
+        return ApiResponseDTO.success("학습 목표 해제 성공");
+    }
+
+    @GetMapping("/active")
+    public ApiResponseDTO<List<LearningGoalDto.ResponseUserGoal>> getActiveGoals(@RequestParam("userId") Long userId) {
+        List<UserGoal> goals = learningGoalService.getActiveGoals(userId);
+
+        List<LearningGoalDto.ResponseUserGoal> result = goals.stream()
+                .map(LearningGoalDto.ResponseUserGoal::from)
+                .toList();
+
+        return ApiResponseDTO.success("진행 중 목표 조회 성공", result);
+    }
+
+    @GetMapping("completed")
+    public ApiResponseDTO<List<LearningGoalDto.ResponseUserGoal>> getCompletedGoals(@RequestParam("userId") Long userId) {
+        List<UserGoal> goals = learningGoalService.getCompletedGoals(userId);
+
+        List<LearningGoalDto.ResponseUserGoal> result = goals.stream()
+                .map(LearningGoalDto.ResponseUserGoal::from)
+                .toList();
+
+        return ApiResponseDTO.success("완료 목표 조회 성공", result);
+    }
+
+    @GetMapping("/available")
+    public ApiResponseDTO<List<LearningGoalDto.ResponseGoalMaster>> getAvailableGoals(@RequestParam("userId") Long userId) {
+        List<GoalMaster> goals = learningGoalService.getAvailableGoals(userId);
+
+        List<LearningGoalDto.ResponseGoalMaster> result = goals.stream()
+                .map(LearningGoalDto.ResponseGoalMaster::from)
+                .toList();
+
+        return ApiResponseDTO.success("선택 가능 목표 조회 성공", result);
+    }
+}

--- a/src/main/java/kr/co/mapspring/learning/controller/LearningGoalController.java
+++ b/src/main/java/kr/co/mapspring/learning/controller/LearningGoalController.java
@@ -1,11 +1,13 @@
 package kr.co.mapspring.learning.controller;
 
 import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.learning.controller.docs.LearningGoalControllerDocs;
 import kr.co.mapspring.learning.dto.LearningGoalDto;
 import kr.co.mapspring.learning.entity.GoalMaster;
 import kr.co.mapspring.learning.entity.UserGoal;
 import kr.co.mapspring.learning.service.LearningGoalService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -13,57 +15,62 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/learning/goals")
 @RequiredArgsConstructor
-public class LearningGoalController {
+public class LearningGoalController implements LearningGoalControllerDocs {
 
     private final LearningGoalService learningGoalService;
 
+    @Override
     @PostMapping
-    public ApiResponseDTO<Void> selectGoal(@RequestBody LearningGoalDto.RequestSelectGoal request) {
+    public ResponseEntity<ApiResponseDTO<Void>> selectGoal(@RequestBody LearningGoalDto.RequestSelectGoal request) {
         learningGoalService.selectGoal(
                 request.getUserId(),
                 request.getGoalMasterId()
         );
 
-        return ApiResponseDTO.success("학습 목표 선택 성공");
+        return ResponseEntity.ok(ApiResponseDTO.success("학습 목표 선택 성공"));
     }
 
+    @Override
     @DeleteMapping("/{userGoalId}")
-    public ApiResponseDTO<Void> calcelGoal(@PathVariable("userGoalId") Long userGoalId) {
+    public ResponseEntity<ApiResponseDTO<Void>> cancelGoal(@PathVariable("userGoalId") Long userGoalId) {
         learningGoalService.cancelGoal(userGoalId);
 
-        return ApiResponseDTO.success("학습 목표 해제 성공");
+        return ResponseEntity.ok(ApiResponseDTO.success("학습 목표 해제 성공"));
     }
 
+    @Override
     @GetMapping("/active")
-    public ApiResponseDTO<List<LearningGoalDto.ResponseUserGoal>> getActiveGoals(@RequestParam("userId") Long userId) {
+    public ResponseEntity<ApiResponseDTO<List<LearningGoalDto.ResponseUserGoal>>> getActiveGoals(@RequestParam("userId") Long userId) {
         List<UserGoal> goals = learningGoalService.getActiveGoals(userId);
 
         List<LearningGoalDto.ResponseUserGoal> result = goals.stream()
                 .map(LearningGoalDto.ResponseUserGoal::from)
                 .toList();
 
-        return ApiResponseDTO.success("진행 중 목표 조회 성공", result);
+        return ResponseEntity.ok(ApiResponseDTO.success("진행 중 목표 조회 성공", result));
     }
 
+    @Override
     @GetMapping("completed")
-    public ApiResponseDTO<List<LearningGoalDto.ResponseUserGoal>> getCompletedGoals(@RequestParam("userId") Long userId) {
+    public ResponseEntity<ApiResponseDTO<List<LearningGoalDto.ResponseUserGoal>>> getCompletedGoals(@RequestParam("userId") Long userId) {
         List<UserGoal> goals = learningGoalService.getCompletedGoals(userId);
 
         List<LearningGoalDto.ResponseUserGoal> result = goals.stream()
                 .map(LearningGoalDto.ResponseUserGoal::from)
                 .toList();
 
-        return ApiResponseDTO.success("완료 목표 조회 성공", result);
+        return ResponseEntity.ok(ApiResponseDTO.success("완료 목표 조회 성공", result));
     }
 
+    @Override
     @GetMapping("/available")
-    public ApiResponseDTO<List<LearningGoalDto.ResponseGoalMaster>> getAvailableGoals(@RequestParam("userId") Long userId) {
+    public ResponseEntity<ApiResponseDTO<List<LearningGoalDto.ResponseGoalMaster>>> getAvailableGoals(@RequestParam("userId") Long userId) {
         List<GoalMaster> goals = learningGoalService.getAvailableGoals(userId);
 
         List<LearningGoalDto.ResponseGoalMaster> result = goals.stream()
                 .map(LearningGoalDto.ResponseGoalMaster::from)
                 .toList();
 
-        return ApiResponseDTO.success("선택 가능 목표 조회 성공", result);
+        return ResponseEntity.ok(ApiResponseDTO.success("선택 가능 목표 조회 성공", result));
     }
 }

--- a/src/main/java/kr/co/mapspring/learning/controller/docs/LearningControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/learning/controller/docs/LearningControllerDocs.java
@@ -1,0 +1,44 @@
+package kr.co.mapspring.learning.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.learning.dto.LearningLogDto;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface LearningControllerDocs {
+
+    @Operation(
+            summary = "학습 기록 조회",
+            description = "사용자의 학습 기록과 점수 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "학습 기록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400",
+                    description = "잘못된 요청값",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseDTO.class)
+                    )
+            )
+    })
+    ResponseEntity<ApiResponseDTO<List<LearningLogDto.ResponseLog>>> getStudyLogs(Long userId);
+}

--- a/src/main/java/kr/co/mapspring/learning/controller/docs/LearningGoalControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/learning/controller/docs/LearningGoalControllerDocs.java
@@ -1,0 +1,91 @@
+package kr.co.mapspring.learning.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.learning.dto.LearningGoalDto;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface LearningGoalControllerDocs {
+
+    @Operation(
+            summary = "학습 목표 선택",
+            description = "사용자가 학습 목표를 선택합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "목표 선택 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            ),
+            @ApiResponse(responseCode = "400",
+                    description = "잘못된 요청 또는 목표 선택 제한 초과",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            ),
+            @ApiResponse(responseCode = "409",
+                    description = "이미 선택한 목표",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            )
+    })
+    ResponseEntity<ApiResponseDTO<Void>> selectGoal(LearningGoalDto.RequestSelectGoal request);
+
+
+    @Operation(
+            summary = "학습 목표 해제",
+            description = "사용자가 선택한 학습 목표를 해제합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "목표 해제 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            ),
+            @ApiResponse(responseCode = "404",
+                    description = "해당 목표를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            )
+    })
+    ResponseEntity<ApiResponseDTO<Void>> cancelGoal(Long userGoalId);
+
+
+    @Operation(
+            summary = "진행 중 학습 목표 조회",
+            description = "사용자의 진행 중인 학습 목표 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            )
+    })
+    ResponseEntity<ApiResponseDTO<List<LearningGoalDto.ResponseUserGoal>>> getActiveGoals(Long userId);
+
+
+    @Operation(
+            summary = "완료된 학습 목표 조회",
+            description = "사용자의 완료된 학습 목표 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            )
+    })
+    ResponseEntity<ApiResponseDTO<List<LearningGoalDto.ResponseUserGoal>>> getCompletedGoals(Long userId);
+
+
+    @Operation(
+            summary = "선택 가능한 학습 목표 조회",
+            description = "사용자가 선택할 수 있는 학습 목표 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            )
+    })
+    ResponseEntity<ApiResponseDTO<List<LearningGoalDto.ResponseGoalMaster>>> getAvailableGoals(Long userId);
+}

--- a/src/main/java/kr/co/mapspring/learning/dto/LearningGoalDto.java
+++ b/src/main/java/kr/co/mapspring/learning/dto/LearningGoalDto.java
@@ -1,0 +1,74 @@
+package kr.co.mapspring.learning.dto;
+
+import kr.co.mapspring.learning.entity.GoalMaster;
+import kr.co.mapspring.learning.entity.UserGoal;
+import kr.co.mapspring.learning.enums.GoalPeriodType;
+import kr.co.mapspring.learning.enums.GoalType;
+import kr.co.mapspring.learning.enums.UserGoalStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+public class LearningGoalDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class RequestSelectGoal {
+        private Long userId;
+        private Long goalMasterId;
+    }
+
+    @Getter
+    @Builder
+    public static class ResponseUserGoal {
+        private Long userGoalId;
+        private Long goalMasterId;
+        private String goalTitle;
+        private GoalType goalType;
+        private GoalPeriodType periodType;
+        private Integer targetValue;
+        private Integer currentValue;
+        private UserGoalStatus status;
+        private LocalDate startDate;
+        private LocalDate endDate;
+
+        public static ResponseUserGoal from(UserGoal userGoal) {
+            GoalMaster goalMaster = userGoal.getGoalMaster();
+
+            return ResponseUserGoal.builder()
+                    .userGoalId(userGoal.getUserGoalId())
+                    .goalMasterId(goalMaster.getGoalMasterId())
+                    .goalTitle(goalMaster.getGoalTitle())
+                    .goalType(goalMaster.getGoalType())
+                    .periodType(goalMaster.getPeriodType())
+                    .targetValue(goalMaster.getTargetValue())
+                    .currentValue(userGoal.getCurrentValue())
+                    .status(userGoal.getStatus())
+                    .startDate(userGoal.getStartDate())
+                    .endDate(userGoal.getEndDate())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ResponseGoalMaster {
+        private Long goalMasterId;
+        private String goalTitle;
+        private GoalType goalType;
+        private GoalPeriodType periodType;
+        private Integer targetValue;
+
+        public static ResponseGoalMaster from(GoalMaster goalMaster) {
+            return ResponseGoalMaster.builder()
+                    .goalMasterId(goalMaster.getGoalMasterId())
+                    .goalTitle(goalMaster.getGoalTitle())
+                    .goalType(goalMaster.getGoalType())
+                    .periodType(goalMaster.getPeriodType())
+                    .targetValue(goalMaster.getTargetValue())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/kr/co/mapspring/learning/dto/LearningGoalDto.java
+++ b/src/main/java/kr/co/mapspring/learning/dto/LearningGoalDto.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.learning.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.mapspring.learning.entity.GoalMaster;
 import kr.co.mapspring.learning.entity.UserGoal;
 import kr.co.mapspring.learning.enums.GoalPeriodType;
@@ -15,23 +16,49 @@ public class LearningGoalDto {
 
     @Getter
     @NoArgsConstructor
+    @Schema(description = "학습 목표 선택 요청 DTO")
     public static class RequestSelectGoal {
+
+        @Schema(description = "사용자 ID", example = "1")
         private Long userId;
+
+        @Schema(description = "목표 마스터 ID", example = "1")
         private Long goalMasterId;
     }
 
     @Getter
     @Builder
+    @Schema(description = "사용자 학습 목표 응답 DTO")
     public static class ResponseUserGoal {
+
+        @Schema(description = "사용자 목표 ID", example = "1")
         private Long userGoalId;
+
+        @Schema(description = "목표 마스터 ID", example = "1")
         private Long goalMasterId;
+
+        @Schema(description = "목표 이름", example = "하루 1회 학습")
         private String goalTitle;
+
+        @Schema(description = "목표 타입", example = "STUDY_COUNT")
         private GoalType goalType;
+
+        @Schema(description = "목표 기간 타입", example = "DAILY")
         private GoalPeriodType periodType;
+
+        @Schema(description = "목표 값", example = "1")
         private Integer targetValue;
+
+        @Schema(description = "현재 진행 값", example = "0")
         private Integer currentValue;
+
+        @Schema(description = "목표 상태", example = "ACTIVE")
         private UserGoalStatus status;
+
+        @Schema(description = "시작 날짜", example = "2026-04-25")
         private LocalDate startDate;
+
+        @Schema(description = "종료 날짜", example = "2026-04-26")
         private LocalDate endDate;
 
         public static ResponseUserGoal from(UserGoal userGoal) {
@@ -54,11 +81,22 @@ public class LearningGoalDto {
 
     @Getter
     @Builder
+    @Schema(description = "목표 마스터 응답 DTO")
     public static class ResponseGoalMaster {
+
+        @Schema(description = "목표 마스터 ID", example = "1")
         private Long goalMasterId;
+
+        @Schema(description = "목표 이름", example = "하루 1회 학습")
         private String goalTitle;
+
+        @Schema(description = "목표 타입", example = "STUDY_COUNT")
         private GoalType goalType;
+
+        @Schema(description = "목표 기간 타입", example = "DAILY")
         private GoalPeriodType periodType;
+
+        @Schema(description = "목표 값", example = "1")
         private Integer targetValue;
 
         public static ResponseGoalMaster from(GoalMaster goalMaster) {

--- a/src/main/java/kr/co/mapspring/learning/dto/LearningLogDto.java
+++ b/src/main/java/kr/co/mapspring/learning/dto/LearningLogDto.java
@@ -1,0 +1,36 @@
+package kr.co.mapspring.learning.dto;
+
+import kr.co.mapspring.learning.entity.StudyLog;
+import kr.co.mapspring.learning.entity.StudyScore;
+import kr.co.mapspring.learning.enums.StudyType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class LearningLogDto {
+
+    @Getter
+    @Builder
+    public static class ResponseLog {
+
+        private Long studyLogId;
+        private StudyType studyType;
+        private Integer earnedExp;
+
+        private Integer naturalnessScore;
+        private Integer fluencyScore;
+        private Integer totalScore;
+
+        public static ResponseLog from(StudyLog log, StudyScore score) {
+            return ResponseLog.builder()
+                    .studyLogId(log.getStudyLogId())
+                    .studyType(log.getStudyType())
+                    .earnedExp(log.getEarnedExp())
+                    .naturalnessScore(score.getNaturalnessScore())
+                    .fluencyScore(score.getFluencyScore())
+                    .totalScore(score.getTotalScore())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/kr/co/mapspring/learning/dto/LearningLogDto.java
+++ b/src/main/java/kr/co/mapspring/learning/dto/LearningLogDto.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.learning.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.mapspring.learning.entity.StudyLog;
 import kr.co.mapspring.learning.entity.StudyScore;
 import kr.co.mapspring.learning.enums.StudyType;
@@ -12,14 +13,28 @@ public class LearningLogDto {
 
     @Getter
     @Builder
+    @Schema(description = "학습 기록 응답 DTO")
     public static class ResponseLog {
 
+        @Schema(description = "학습 기록 ID", example = "1")
         private Long studyLogId;
+
+        @Schema(description = "세션 ID", example = "10")
+        private Long sessionId;
+
+        @Schema(description = "학습 타입", example = "SCENARIO")
         private StudyType studyType;
+
+        @Schema(description = "획득 경험치", example = "20")
         private Integer earnedExp;
 
+        @Schema(description = "자연스러움 점수", example = "80")
         private Integer naturalnessScore;
+
+        @Schema(description = "유창성 점수", example = "70")
         private Integer fluencyScore;
+
+        @Schema(description = "총 점수", example = "75")
         private Integer totalScore;
 
         public static ResponseLog from(StudyLog log, StudyScore score) {

--- a/src/main/java/kr/co/mapspring/learning/entity/StudyLog.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/StudyLog.java
@@ -1,0 +1,64 @@
+package kr.co.mapspring.learning.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kr.co.mapspring.learning.enums.StudyType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "study_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_log_id", nullable = false, updatable = false)
+    private Long studyLogId;
+
+//    TODO: 추후 User 엔티티 확정 시 연관관계로 매핑 예정
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+//    TODO: 추후 Session 엔티티 확정 시 연관관계로 매핑 예정
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+    @Column(name = "session_id", nullable = false)
+    private Long sessionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "study_type", nullable = false, length = 50)
+    private StudyType studyType;
+
+    @Column(name = "earned_exp", nullable = false)
+    private Integer earnedExp;
+
+    public static StudyLog create(Long userId, Long sessionId, StudyType studyType, Integer earnedExp) {
+        StudyLog studyLog = new StudyLog();
+        studyLog.userId = userId;
+        studyLog.sessionId = sessionId;
+        studyLog.studyType = studyType;
+        studyLog.earnedExp = earnedExp;
+        return studyLog;
+    }
+
+    // 테스트 전용 메서드
+    public static StudyLog of(Long studyLogId, Long userId, Long sessionId, StudyType studyType, Integer earnedExp) {
+        StudyLog studyLog = new StudyLog();
+        studyLog.studyLogId = studyLogId;
+        studyLog.userId = userId;
+        studyLog.sessionId = sessionId;
+        studyLog.studyType = studyType;
+        studyLog.earnedExp = earnedExp;
+        return studyLog;
+    }
+}

--- a/src/main/java/kr/co/mapspring/learning/entity/StudyLog.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/StudyLog.java
@@ -12,6 +12,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kr.co.mapspring.learning.enums.StudyType;
+import kr.co.mapspring.place.entity.LearningSession;
+import kr.co.mapspring.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,17 +28,13 @@ public class StudyLog {
     @Column(name = "study_log_id", nullable = false, updatable = false)
     private Long studyLogId;
 
-//    TODO: 추후 User 엔티티 확정 시 연관관계로 매핑 예정
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-//    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    private User user;
 
-//    TODO: 추후 Session 엔티티 확정 시 연관관계로 매핑 예정
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "user_id", nullable = false)
-    @Column(name = "session_id", nullable = false)
-    private Long sessionId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private LearningSession learningSession;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "study_type", nullable = false, length = 50)
@@ -45,21 +43,21 @@ public class StudyLog {
     @Column(name = "earned_exp", nullable = false)
     private Integer earnedExp;
 
-    public static StudyLog create(Long userId, Long sessionId, StudyType studyType, Integer earnedExp) {
+    public static StudyLog create(User user, LearningSession learningSession, StudyType studyType, Integer earnedExp) {
         StudyLog studyLog = new StudyLog();
-        studyLog.userId = userId;
-        studyLog.sessionId = sessionId;
+        studyLog.user = user;
+        studyLog.learningSession = learningSession;
         studyLog.studyType = studyType;
         studyLog.earnedExp = earnedExp;
         return studyLog;
     }
 
     // 테스트 전용 메서드
-    public static StudyLog of(Long studyLogId, Long userId, Long sessionId, StudyType studyType, Integer earnedExp) {
+    public static StudyLog of(Long studyLogId, User user, LearningSession learningSession, StudyType studyType, Integer earnedExp) {
         StudyLog studyLog = new StudyLog();
         studyLog.studyLogId = studyLogId;
-        studyLog.userId = userId;
-        studyLog.sessionId = sessionId;
+        studyLog.user = user;
+        studyLog.learningSession = learningSession;
         studyLog.studyType = studyType;
         studyLog.earnedExp = earnedExp;
         return studyLog;

--- a/src/main/java/kr/co/mapspring/learning/entity/StudyScore.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/StudyScore.java
@@ -1,0 +1,57 @@
+package kr.co.mapspring.learning.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "study_score")
+@Getter
+@NoArgsConstructor
+public class StudyScore {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_score_id", nullable = false, updatable = false)
+    private Long studyScoreId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_log_id", nullable = false, unique = true)
+    private StudyLog studyLog;
+
+    @Column(name = "naturalness_score")
+    private Integer naturalnessScore;
+
+    @Column(name = "fluency_score")
+    private Integer fluencyScore;
+
+    @Column(name = "total_score")
+    private Integer totalScore;
+
+    public static StudyScore create(StudyLog studyLog, Integer naturalnessScore, Integer fluencyScore, Integer totalScore) {
+        StudyScore studyScore = new StudyScore();
+        studyScore.studyLog = studyLog;
+        studyScore.naturalnessScore = naturalnessScore;
+        studyScore.fluencyScore = fluencyScore;
+        studyScore.totalScore = totalScore;
+        return studyScore;
+    }
+
+    // 테스트 전용 메서드
+    public static StudyScore of(Long studyScoreId, StudyLog studyLog, Integer naturalnessScore, Integer fluencyScore, Integer totalScore) {
+        StudyScore studyScore = new StudyScore();
+        studyScore.studyScoreId = studyScoreId;
+        studyScore.studyLog = studyLog;
+        studyScore.naturalnessScore = naturalnessScore;
+        studyScore.fluencyScore = fluencyScore;
+        studyScore.totalScore = totalScore;
+        return studyScore;
+    }
+}

--- a/src/main/java/kr/co/mapspring/learning/entity/UserGoal.java
+++ b/src/main/java/kr/co/mapspring/learning/entity/UserGoal.java
@@ -14,6 +14,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import kr.co.mapspring.learning.enums.UserGoalStatus;
+import kr.co.mapspring.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,11 +33,9 @@ public class UserGoal {
     @Column(name = "user_goal_id", nullable = false, updatable = false)
     private Long userGoalId;
 
-//    TODO: 엔티티 확정 후 매핑 예정
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "user_id", nullable = false)
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "goal_master_id", nullable = false)
@@ -75,9 +74,9 @@ public class UserGoal {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public static UserGoal create(Long userId, GoalMaster goalMaster, LocalDate startDate, LocalDate endDate) {
+    public static UserGoal create(User user, GoalMaster goalMaster, LocalDate startDate, LocalDate endDate) {
         UserGoal userGoal = new UserGoal();
-        userGoal.userId = userId;
+        userGoal.user = user;
         userGoal.goalMaster = goalMaster;
         userGoal.currentValue = 0;
         userGoal.status = UserGoalStatus.ACTIVE;
@@ -108,10 +107,10 @@ public class UserGoal {
     }
 
     // 테스트 전용 생성 메서드
-    public static UserGoal of(Long userGoalId, Long userId, GoalMaster goalMaster, Integer currentValue, UserGoalStatus status, LocalDate startDate, LocalDate endDate) {
+    public static UserGoal of(Long userGoalId, User user, GoalMaster goalMaster, Integer currentValue, UserGoalStatus status, LocalDate startDate, LocalDate endDate) {
         UserGoal userGoal = new UserGoal();
         userGoal.userGoalId = userGoalId;
-        userGoal.userId = userId;
+        userGoal.user = user;
         userGoal.goalMaster = goalMaster;
         userGoal.currentValue = currentValue;
         userGoal.status = status;

--- a/src/main/java/kr/co/mapspring/learning/repository/StudyLogRepository.java
+++ b/src/main/java/kr/co/mapspring/learning/repository/StudyLogRepository.java
@@ -1,0 +1,7 @@
+package kr.co.mapspring.learning.repository;
+
+import kr.co.mapspring.learning.entity.StudyLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyLogRepository extends JpaRepository<StudyLog, Long> {
+}

--- a/src/main/java/kr/co/mapspring/learning/repository/StudyLogRepository.java
+++ b/src/main/java/kr/co/mapspring/learning/repository/StudyLogRepository.java
@@ -4,4 +4,5 @@ import kr.co.mapspring.learning.entity.StudyLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyLogRepository extends JpaRepository<StudyLog, Long> {
+
 }

--- a/src/main/java/kr/co/mapspring/learning/repository/StudyScoreRepository.java
+++ b/src/main/java/kr/co/mapspring/learning/repository/StudyScoreRepository.java
@@ -1,0 +1,7 @@
+package kr.co.mapspring.learning.repository;
+
+import kr.co.mapspring.learning.entity.StudyScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyScoreRepository extends JpaRepository<StudyScore, Long> {
+}

--- a/src/main/java/kr/co/mapspring/learning/repository/StudyScoreRepository.java
+++ b/src/main/java/kr/co/mapspring/learning/repository/StudyScoreRepository.java
@@ -3,5 +3,9 @@ package kr.co.mapspring.learning.repository;
 import kr.co.mapspring.learning.entity.StudyScore;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StudyScoreRepository extends JpaRepository<StudyScore, Long> {
+
+    List<StudyScore> findAllByStudyLog_UserId(Long userId);
 }

--- a/src/main/java/kr/co/mapspring/learning/repository/UserGoalRepository.java
+++ b/src/main/java/kr/co/mapspring/learning/repository/UserGoalRepository.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 public interface UserGoalRepository extends JpaRepository<UserGoal, Long> {
 
-    boolean existsByUserIdAndGoalMaster_GoalMasterId(Long userId, Long goalMasterId);
+    boolean existsByUser_UserIdAndGoalMaster_GoalMasterId(Long userId, Long goalMasterId);
 
-    int countByUserId(Long userId);
+    int countByUser_UserId(Long userId);
 
-    List<UserGoal> findAllByUserIdAndStatus(Long userId, UserGoalStatus status);
+    List<UserGoal> findAllByUser_UserIdAndStatus(Long userId, UserGoalStatus status);
 
 }

--- a/src/main/java/kr/co/mapspring/learning/service/LearningService.java
+++ b/src/main/java/kr/co/mapspring/learning/service/LearningService.java
@@ -1,6 +1,9 @@
 package kr.co.mapspring.learning.service;
 
+import kr.co.mapspring.learning.dto.LearningLogDto;
 import kr.co.mapspring.learning.enums.StudyType;
+
+import java.util.List;
 
 public interface LearningService {
 
@@ -16,4 +19,12 @@ public interface LearningService {
      * @param totalScore 종합 점수
      */
     void recordStudyLog(Long userId, Long sessionId, StudyType studyType, Integer earnedExp, Integer naturalnessScore, Integer fluencyScore, Integer totalScore);
+
+    /**
+     * 사용자의 학습 기록 목록을 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @return 학습 기록 목록
+     */
+    List<LearningLogDto.ResponseLog> getStudyLogs(Long userId);
 }

--- a/src/main/java/kr/co/mapspring/learning/service/LearningService.java
+++ b/src/main/java/kr/co/mapspring/learning/service/LearningService.java
@@ -1,0 +1,19 @@
+package kr.co.mapspring.learning.service;
+
+import kr.co.mapspring.learning.enums.StudyType;
+
+public interface LearningService {
+
+    /**
+     * 학습 완료 후 학습 기록과 점수를 저장한다.
+     *
+     * @param userId 사용자 ID
+     * @param sessionId 학습 세션 ID
+     * @param studyType 학습 유형
+     * @param earnedExp 획득 경험치
+     * @param naturalnessScore 문장 자연스러움 점수
+     * @param fluencyScore 유창성 점수
+     * @param totalScore 종합 점수
+     */
+    void recordStudyLog(Long userId, Long sessionId, StudyType studyType, Integer earnedExp, Integer naturalnessScore, Integer fluencyScore, Integer totalScore);
+}

--- a/src/main/java/kr/co/mapspring/learning/service/impl/LearningGoalServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/learning/service/impl/LearningGoalServiceImpl.java
@@ -4,6 +4,7 @@ import kr.co.mapspring.global.exception.learning.GoalAlreadySelectedException;
 import kr.co.mapspring.global.exception.learning.GoalMasterNotFoundException;
 import kr.co.mapspring.global.exception.learning.GoalSelectionLimitExceededException;
 import kr.co.mapspring.global.exception.learning.UserGoalNotFoundException;
+import kr.co.mapspring.global.exception.user.UserNotFoundException;
 import kr.co.mapspring.learning.entity.GoalMaster;
 import kr.co.mapspring.learning.entity.UserGoal;
 import kr.co.mapspring.learning.enums.GoalType;
@@ -11,6 +12,8 @@ import kr.co.mapspring.learning.enums.UserGoalStatus;
 import kr.co.mapspring.learning.repository.GoalMasterRepository;
 import kr.co.mapspring.learning.repository.UserGoalRepository;
 import kr.co.mapspring.learning.service.LearningGoalService;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,21 +31,25 @@ public class LearningGoalServiceImpl implements LearningGoalService {
 
     private final GoalMasterRepository goalMasterRepository;
     private final UserGoalRepository userGoalRepository;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional
     public void selectGoal(Long userId, Long goalMasterId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
         GoalMaster goalMaster = goalMasterRepository.findById(goalMasterId)
                 .orElseThrow(GoalMasterNotFoundException::new);
 
         boolean alreadySelected =
-                userGoalRepository.existsByUserIdAndGoalMaster_GoalMasterId(userId, goalMasterId);
+                userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterId(userId, goalMasterId);
 
         if (alreadySelected) {
             throw new GoalAlreadySelectedException();
         }
 
-        int selectedCount = userGoalRepository.countByUserId(userId);
+        int selectedCount = userGoalRepository.countByUser_UserId(userId);
 
         if (selectedCount > MAX_GOAL_COUNT) {
             throw new GoalSelectionLimitExceededException();
@@ -51,7 +58,7 @@ public class LearningGoalServiceImpl implements LearningGoalService {
         LocalDate startDate = LocalDate.now();
         LocalDate endDate = calculateEndDate(startDate, goalMaster);
 
-        UserGoal userGoal = UserGoal.create(userId, goalMaster, startDate, endDate);
+        UserGoal userGoal = UserGoal.create(user, goalMaster, startDate, endDate);
 
         userGoalRepository.save(userGoal);
     }
@@ -67,7 +74,7 @@ public class LearningGoalServiceImpl implements LearningGoalService {
 
     @Override
     public List<UserGoal> getActiveGoals(Long userId) {
-        return userGoalRepository.findAllByUserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        return userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
     }
 
     private LocalDate calculateEndDate(LocalDate startDate, GoalMaster goalMaster) {
@@ -82,7 +89,7 @@ public class LearningGoalServiceImpl implements LearningGoalService {
     @Override
     @Transactional
     public void updateGoalProgress(Long userId, GoalType goalType, Integer amount) {
-        List<UserGoal> activeGoals = userGoalRepository.findAllByUserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        List<UserGoal> activeGoals = userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
 
         for (UserGoal userGoal : activeGoals) {
             if (userGoal.getGoalMaster().getGoalType() != goalType) {
@@ -100,13 +107,13 @@ public class LearningGoalServiceImpl implements LearningGoalService {
 
     @Override
     public List<UserGoal> getCompletedGoals(Long userId) {
-        return userGoalRepository.findAllByUserIdAndStatus(userId, UserGoalStatus.COMPLETED);
+        return userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.COMPLETED);
     }
 
     @Override
     public List<GoalMaster> getAvailableGoals(Long userId) {
         List<GoalMaster> activeGoalMasters = goalMasterRepository.findAllByIsActiveTrue();
-        List<UserGoal> activeUserGoals = userGoalRepository.findAllByUserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        List<UserGoal> activeUserGoals = userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
 
         Set<Long> selectedGoalIds = activeUserGoals.stream()
                 .map(userGoal -> userGoal.getGoalMaster().getGoalMasterId())

--- a/src/main/java/kr/co/mapspring/learning/service/impl/LearningServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/learning/service/impl/LearningServiceImpl.java
@@ -2,9 +2,11 @@ package kr.co.mapspring.learning.service.impl;
 
 import kr.co.mapspring.learning.entity.StudyLog;
 import kr.co.mapspring.learning.entity.StudyScore;
+import kr.co.mapspring.learning.enums.GoalType;
 import kr.co.mapspring.learning.enums.StudyType;
 import kr.co.mapspring.learning.repository.StudyLogRepository;
 import kr.co.mapspring.learning.repository.StudyScoreRepository;
+import kr.co.mapspring.learning.service.LearningGoalService;
 import kr.co.mapspring.learning.service.LearningService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,7 @@ public class LearningServiceImpl implements LearningService {
 
     private final StudyLogRepository studyLogRepository;
     private final StudyScoreRepository studyScoreRepository;
+    private final LearningGoalService learningGoalService;
 
     @Override
     @Transactional
@@ -39,5 +42,7 @@ public class LearningServiceImpl implements LearningService {
         );
 
         studyScoreRepository.save(studyScore);
+
+        learningGoalService.updateGoalProgress(userId, GoalType.STUDY_COUNT, 1);
     }
 }

--- a/src/main/java/kr/co/mapspring/learning/service/impl/LearningServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/learning/service/impl/LearningServiceImpl.java
@@ -1,0 +1,43 @@
+package kr.co.mapspring.learning.service.impl;
+
+import kr.co.mapspring.learning.entity.StudyLog;
+import kr.co.mapspring.learning.entity.StudyScore;
+import kr.co.mapspring.learning.enums.StudyType;
+import kr.co.mapspring.learning.repository.StudyLogRepository;
+import kr.co.mapspring.learning.repository.StudyScoreRepository;
+import kr.co.mapspring.learning.service.LearningService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LearningServiceImpl implements LearningService {
+
+    private final StudyLogRepository studyLogRepository;
+    private final StudyScoreRepository studyScoreRepository;
+
+    @Override
+    @Transactional
+    public void recordStudyLog(Long userId, Long sessionId, StudyType studyType, Integer earnedExp, Integer naturalnessScore, Integer fluencyScore, Integer totalScore) {
+
+        StudyLog studyLog = StudyLog.create(
+                userId,
+                sessionId,
+                studyType,
+                earnedExp
+        );
+
+        StudyLog savedStudyLog = studyLogRepository.save(studyLog);
+
+        StudyScore studyScore = StudyScore.create(
+                savedStudyLog,
+                naturalnessScore,
+                fluencyScore,
+                totalScore
+        );
+
+        studyScoreRepository.save(studyScore);
+    }
+}

--- a/src/main/java/kr/co/mapspring/learning/service/impl/LearningServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/learning/service/impl/LearningServiceImpl.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.learning.service.impl;
 
+import kr.co.mapspring.global.exception.user.UserNotFoundException;
 import kr.co.mapspring.learning.entity.StudyLog;
 import kr.co.mapspring.learning.entity.StudyScore;
 import kr.co.mapspring.learning.enums.GoalType;
@@ -8,6 +9,10 @@ import kr.co.mapspring.learning.repository.StudyLogRepository;
 import kr.co.mapspring.learning.repository.StudyScoreRepository;
 import kr.co.mapspring.learning.service.LearningGoalService;
 import kr.co.mapspring.learning.service.LearningService;
+import kr.co.mapspring.place.entity.LearningSession;
+import kr.co.mapspring.place.repository.LearningSessionRepository;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,14 +25,23 @@ public class LearningServiceImpl implements LearningService {
     private final StudyLogRepository studyLogRepository;
     private final StudyScoreRepository studyScoreRepository;
     private final LearningGoalService learningGoalService;
+    private final UserRepository userRepository;
+    private final LearningSessionRepository learningSessionRepository;
 
     @Override
     @Transactional
     public void recordStudyLog(Long userId, Long sessionId, StudyType studyType, Integer earnedExp, Integer naturalnessScore, Integer fluencyScore, Integer totalScore) {
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+//      TODO: 추후 공통 예외처리 예정
+        LearningSession session = learningSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("세션 없음"));
+
         StudyLog studyLog = StudyLog.create(
-                userId,
-                sessionId,
+                user,
+                session,
                 studyType,
                 earnedExp
         );

--- a/src/main/java/kr/co/mapspring/learning/service/impl/LearningServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/learning/service/impl/LearningServiceImpl.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.learning.service.impl;
 
+import kr.co.mapspring.learning.dto.LearningLogDto;
 import kr.co.mapspring.learning.entity.StudyLog;
 import kr.co.mapspring.learning.entity.StudyScore;
 import kr.co.mapspring.learning.enums.GoalType;
@@ -11,6 +12,8 @@ import kr.co.mapspring.learning.service.LearningService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +47,17 @@ public class LearningServiceImpl implements LearningService {
         studyScoreRepository.save(studyScore);
 
         learningGoalService.updateGoalProgress(userId, GoalType.STUDY_COUNT, 1);
+    }
+
+    @Override
+    public List<LearningLogDto.ResponseLog> getStudyLogs(Long userId) {
+        List<StudyScore> studyScores = studyScoreRepository.findAllByStudyLog_UserId(userId);
+
+        return studyScores.stream()
+                .map(studyScore -> LearningLogDto.ResponseLog.from(
+                        studyScore.getStudyLog(),
+                        studyScore
+                ))
+                .toList();
     }
 }

--- a/src/main/java/kr/co/mapspring/place/service/AdminPlaceService.java
+++ b/src/main/java/kr/co/mapspring/place/service/AdminPlaceService.java
@@ -1,91 +1,91 @@
-
-package kr.co.mapspring.place.service;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import kr.co.mapspring.global.exception.place.PlaceAlreadyExistsException;
-import kr.co.mapspring.global.exception.place.PlaceNotFoundException;
-import kr.co.mapspring.global.exception.place.RegionNotFoundException;
-import kr.co.mapspring.global.exception.place.ScenarioNotFoundException;
-import kr.co.mapspring.place.dto.AdminCreatePlaceDto;
-import kr.co.mapspring.place.dto.AdminReadPlaceDto;
-import kr.co.mapspring.place.entity.Place;
-import kr.co.mapspring.place.entity.Region;
-import kr.co.mapspring.place.entity.Scenario;
-import kr.co.mapspring.place.repository.PlaceRepository;
-import kr.co.mapspring.place.repository.RegionRepository;
-import kr.co.mapspring.place.repository.ScenarioRepository;
-import lombok.RequiredArgsConstructor;
-
-@Service
-@RequiredArgsConstructor
-public class AdminPlaceService {
-
-	private final PlaceRepository placeRepository;
-	private final RegionRepository regionRepository;
-	private final ScenarioRepository scenarioRepository;
-
-	// 장소 생성
-	@Transactional
-	public void savePlace(AdminCreatePlaceDto.RequestCreate request) {
-
-		Long regionId = request.getRegionId();
-		Long scenarioId = request.getScenarioId();
-		String googlePlaceId = request.getGooglePlaceId();
-
-		boolean placeExists = placeRepository.existsByGooglePlaceId(googlePlaceId);
-
-		if (placeExists) {
-			throw new PlaceAlreadyExistsException();
-		}
-
-		Region regionEntity = regionRepository.findById(regionId)
-				.orElseThrow(RegionNotFoundException::new);
-
-		Scenario scenarioEntity = scenarioRepository.findById(scenarioId)
-				.orElseThrow(ScenarioNotFoundException::new);
-
-		Place place = Place.create(request.getGooglePlaceId(),
-							   request.getPlaceName(),
-							   request.getPlaceAddress(),
-							   request.getPlaceDescription(),
-							   request.getLatitude(),
-							   request.getLongitude(),
-							   scenarioEntity,
-							   regionEntity
-							   );
-
-		placeRepository.save(place);
-	}
-
-	// 장소 조회
-	@Transactional(readOnly = true)
-	public AdminReadPlaceDto.ResponseRead readPlace(AdminReadPlaceDto.RequestRead request) {
-
-		Long placeId = request.getPlaceId();
-
-		Place place = placeRepository.findById(placeId)
-				.orElseThrow(PlaceNotFoundException::new);
-
-		AdminReadPlaceDto.ResponseRead response = AdminReadPlaceDto.ResponseRead.from(place);
-
-		return response;
-	}
-
-	// 장소 수정
-	@Transactional
-	public void updatePlace(Long placeId, AdminUpdatePlaceDto.RequestUpdate request) {
-
-		Place place = placeRepository.findById(placeId)
-				.orElseThrow(PlaceNotFoundException::new);
-
-		Long scenarioId = request.getScenarioId();
-
-		Scenario scenario = scenarioRepository.findById(scenarioId)
-				.orElseThrow(ScenarioNotFoundException::new);
-
-		place.update(request.getPlaceName(),
-				 request.getPlaceDescription(),
-				 scenario);
-	}
-}
+//
+//package kr.co.mapspring.place.service;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import kr.co.mapspring.global.exception.place.PlaceAlreadyExistsException;
+//import kr.co.mapspring.global.exception.place.PlaceNotFoundException;
+//import kr.co.mapspring.global.exception.place.RegionNotFoundException;
+//import kr.co.mapspring.global.exception.place.ScenarioNotFoundException;
+//import kr.co.mapspring.place.dto.AdminCreatePlaceDto;
+//import kr.co.mapspring.place.dto.AdminReadPlaceDto;
+//import kr.co.mapspring.place.entity.Place;
+//import kr.co.mapspring.place.entity.Region;
+//import kr.co.mapspring.place.entity.Scenario;
+//import kr.co.mapspring.place.repository.PlaceRepository;
+//import kr.co.mapspring.place.repository.RegionRepository;
+//import kr.co.mapspring.place.repository.ScenarioRepository;
+//import lombok.RequiredArgsConstructor;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class AdminPlaceService {
+//
+//	private final PlaceRepository placeRepository;
+//	private final RegionRepository regionRepository;
+//	private final ScenarioRepository scenarioRepository;
+//
+//	// 장소 생성
+//	@Transactional
+//	public void savePlace(AdminCreatePlaceDto.RequestCreate request) {
+//
+//		Long regionId = request.getRegionId();
+//		Long scenarioId = request.getScenarioId();
+//		String googlePlaceId = request.getGooglePlaceId();
+//
+//		boolean placeExists = placeRepository.existsByGooglePlaceId(googlePlaceId);
+//
+//		if (placeExists) {
+//			throw new PlaceAlreadyExistsException();
+//		}
+//
+//		Region regionEntity = regionRepository.findById(regionId)
+//				.orElseThrow(RegionNotFoundException::new);
+//
+//		Scenario scenarioEntity = scenarioRepository.findById(scenarioId)
+//				.orElseThrow(ScenarioNotFoundException::new);
+//
+//		Place place = Place.create(request.getGooglePlaceId(),
+//							   request.getPlaceName(),
+//							   request.getPlaceAddress(),
+//							   request.getPlaceDescription(),
+//							   request.getLatitude(),
+//							   request.getLongitude(),
+//							   scenarioEntity,
+//							   regionEntity
+//							   );
+//
+//		placeRepository.save(place);
+//	}
+//
+//	// 장소 조회
+//	@Transactional(readOnly = true)
+//	public AdminReadPlaceDto.ResponseRead readPlace(AdminReadPlaceDto.RequestRead request) {
+//
+//		Long placeId = request.getPlaceId();
+//
+//		Place place = placeRepository.findById(placeId)
+//				.orElseThrow(PlaceNotFoundException::new);
+//
+//		AdminReadPlaceDto.ResponseRead response = AdminReadPlaceDto.ResponseRead.from(place);
+//
+//		return response;
+//	}
+//
+//	// 장소 수정
+//	@Transactional
+//	public void updatePlace(Long placeId, AdminUpdatePlaceDto.RequestUpdate request) {
+//
+//		Place place = placeRepository.findById(placeId)
+//				.orElseThrow(PlaceNotFoundException::new);
+//
+//		Long scenarioId = request.getScenarioId();
+//
+//		Scenario scenario = scenarioRepository.findById(scenarioId)
+//				.orElseThrow(ScenarioNotFoundException::new);
+//
+//		place.update(request.getPlaceName(),
+//				 request.getPlaceDescription(),
+//				 scenario);
+//	}
+//}

--- a/src/main/java/kr/co/mapspring/place/service/AdminPlaceService.java
+++ b/src/main/java/kr/co/mapspring/place/service/AdminPlaceService.java
@@ -1,91 +1,91 @@
-
-package kr.co.mapspring.place.service;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import kr.co.mapspring.global.exception.place.PlaceAlreadyExistsException;
-import kr.co.mapspring.global.exception.place.PlaceNotFoundException;
-import kr.co.mapspring.global.exception.place.RegionNotFoundException;
-import kr.co.mapspring.global.exception.place.ScenarioNotFoundException;
-import kr.co.mapspring.place.dto.AdminCreatePlaceDto;
-import kr.co.mapspring.place.dto.AdminReadPlaceDto;
-import kr.co.mapspring.place.entity.Place;
-import kr.co.mapspring.place.entity.Region;
-import kr.co.mapspring.place.entity.Scenario;
-import kr.co.mapspring.place.repository.PlaceRepository;
-import kr.co.mapspring.place.repository.RegionRepository;
-import kr.co.mapspring.place.repository.ScenarioRepository;
-import lombok.RequiredArgsConstructor;
-
-@Service
-@RequiredArgsConstructor
-public class AdminPlaceService {
-
-	private final PlaceRepository placeRepository;
-	private final RegionRepository regionRepository;
-	private final ScenarioRepository scenarioRepository;
-
-	// 장소 생성
-	@Transactional
-	public void savePlace(AdminCreatePlaceDto.RequestCreate request) {
-		
-		Long regionId = request.getRegionId();
-		Long scenarioId = request.getScenarioId();
-		String googlePlaceId = request.getGooglePlaceId();
-		
-		boolean placeExists = placeRepository.existsByGooglePlaceId(googlePlaceId);
-		
-		if (placeExists) {
-			throw new PlaceAlreadyExistsException();
-		}
-								
-		Region regionEntity = regionRepository.findById(regionId)
-				.orElseThrow(RegionNotFoundException::new);
-		
-		Scenario scenarioEntity = scenarioRepository.findById(scenarioId)
-				.orElseThrow(ScenarioNotFoundException::new);
-		
-		Place place = Place.create(request.getGooglePlaceId(),
-							   request.getPlaceName(),
-							   request.getPlaceAddress(),
-							   request.getPlaceDescription(),
-							   request.getLatitude(),
-							   request.getLongitude(),
-							   scenarioEntity,
-							   regionEntity
-							   );
-
-		placeRepository.save(place);
-	}
-	
-	// 장소 조회
-	@Transactional(readOnly = true)
-	public AdminReadPlaceDto.ResponseRead readPlace(AdminReadPlaceDto.RequestRead request) {
-		
-		Long placeId = request.getPlaceId();
-		
-		Place place = placeRepository.findById(placeId)
-				.orElseThrow(PlaceNotFoundException::new);
-		
-		AdminReadPlaceDto.ResponseRead response = AdminReadPlaceDto.ResponseRead.from(place);
-		
-		return response;
-	}
-	
-	// 장소 수정
-	@Transactional
-	public void updatePlace(Long placeId, AdminUpdatePlaceDto.RequestUpdate request) {
-		
-		Place place = placeRepository.findById(placeId)
-				.orElseThrow(PlaceNotFoundException::new);
-		
-		Long scenarioId = request.getScenarioId();
-		
-		Scenario scenario = scenarioRepository.findById(scenarioId)
-				.orElseThrow(ScenarioNotFoundException::new);
-		
-		place.update(request.getPlaceName(),
-				 request.getPlaceDescription(),
-				 scenario);
-	}
-}
+//
+//package kr.co.mapspring.place.service;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import kr.co.mapspring.global.exception.place.PlaceAlreadyExistsException;
+//import kr.co.mapspring.global.exception.place.PlaceNotFoundException;
+//import kr.co.mapspring.global.exception.place.RegionNotFoundException;
+//import kr.co.mapspring.global.exception.place.ScenarioNotFoundException;
+//import kr.co.mapspring.place.dto.AdminCreatePlaceDto;
+//import kr.co.mapspring.place.dto.AdminReadPlaceDto;
+//import kr.co.mapspring.place.entity.Place;
+//import kr.co.mapspring.place.entity.Region;
+//import kr.co.mapspring.place.entity.Scenario;
+//import kr.co.mapspring.place.repository.PlaceRepository;
+//import kr.co.mapspring.place.repository.RegionRepository;
+//import kr.co.mapspring.place.repository.ScenarioRepository;
+//import lombok.RequiredArgsConstructor;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class AdminPlaceService {
+//
+//	private final PlaceRepository placeRepository;
+//	private final RegionRepository regionRepository;
+//	private final ScenarioRepository scenarioRepository;
+//
+//	// 장소 생성
+//	@Transactional
+//	public void savePlace(AdminCreatePlaceDto.RequestCreate request) {
+//
+//		Long regionId = request.getRegionId();
+//		Long scenarioId = request.getScenarioId();
+//		String googlePlaceId = request.getGooglePlaceId();
+//
+//		boolean placeExists = placeRepository.existsByGooglePlaceId(googlePlaceId);
+//
+//		if (placeExists) {
+//			throw new PlaceAlreadyExistsException();
+//		}
+//
+//		Region regionEntity = regionRepository.findById(regionId)
+//				.orElseThrow(RegionNotFoundException::new);
+//
+//		Scenario scenarioEntity = scenarioRepository.findById(scenarioId)
+//				.orElseThrow(ScenarioNotFoundException::new);
+//
+//		Place place = Place.create(request.getGooglePlaceId(),
+//							   request.getPlaceName(),
+//							   request.getPlaceAddress(),
+//							   request.getPlaceDescription(),
+//							   request.getLatitude(),
+//							   request.getLongitude(),
+//							   scenarioEntity,
+//							   regionEntity
+//							   );
+//
+//		placeRepository.save(place);
+//	}
+//
+//	// 장소 조회
+//	@Transactional(readOnly = true)
+//	public AdminReadPlaceDto.ResponseRead readPlace(AdminReadPlaceDto.RequestRead request) {
+//
+//		Long placeId = request.getPlaceId();
+//
+//		Place place = placeRepository.findById(placeId)
+//				.orElseThrow(PlaceNotFoundException::new);
+//
+//		AdminReadPlaceDto.ResponseRead response = AdminReadPlaceDto.ResponseRead.from(place);
+//
+//		return response;
+//	}
+//
+//	// 장소 수정
+//	@Transactional
+//	public void updatePlace(Long placeId, AdminUpdatePlaceDto.RequestUpdate request) {
+//
+//		Place place = placeRepository.findById(placeId)
+//				.orElseThrow(PlaceNotFoundException::new);
+//
+//		Long scenarioId = request.getScenarioId();
+//
+//		Scenario scenario = scenarioRepository.findById(scenarioId)
+//				.orElseThrow(ScenarioNotFoundException::new);
+//
+//		place.update(request.getPlaceName(),
+//				 request.getPlaceDescription(),
+//				 scenario);
+//	}
+//}

--- a/src/main/java/kr/co/mapspring/place/service/AdminPlaceService.java
+++ b/src/main/java/kr/co/mapspring/place/service/AdminPlaceService.java
@@ -1,91 +1,91 @@
-//
-//package kr.co.mapspring.place.service;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import kr.co.mapspring.global.exception.place.PlaceAlreadyExistsException;
-//import kr.co.mapspring.global.exception.place.PlaceNotFoundException;
-//import kr.co.mapspring.global.exception.place.RegionNotFoundException;
-//import kr.co.mapspring.global.exception.place.ScenarioNotFoundException;
-//import kr.co.mapspring.place.dto.AdminCreatePlaceDto;
-//import kr.co.mapspring.place.dto.AdminReadPlaceDto;
-//import kr.co.mapspring.place.entity.Place;
-//import kr.co.mapspring.place.entity.Region;
-//import kr.co.mapspring.place.entity.Scenario;
-//import kr.co.mapspring.place.repository.PlaceRepository;
-//import kr.co.mapspring.place.repository.RegionRepository;
-//import kr.co.mapspring.place.repository.ScenarioRepository;
-//import lombok.RequiredArgsConstructor;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class AdminPlaceService {
-//
-//	private final PlaceRepository placeRepository;
-//	private final RegionRepository regionRepository;
-//	private final ScenarioRepository scenarioRepository;
-//
-//	// 장소 생성
-//	@Transactional
-//	public void savePlace(AdminCreatePlaceDto.RequestCreate request) {
-//
-//		Long regionId = request.getRegionId();
-//		Long scenarioId = request.getScenarioId();
-//		String googlePlaceId = request.getGooglePlaceId();
-//
-//		boolean placeExists = placeRepository.existsByGooglePlaceId(googlePlaceId);
-//
-//		if (placeExists) {
-//			throw new PlaceAlreadyExistsException();
-//		}
-//
-//		Region regionEntity = regionRepository.findById(regionId)
-//				.orElseThrow(RegionNotFoundException::new);
-//
-//		Scenario scenarioEntity = scenarioRepository.findById(scenarioId)
-//				.orElseThrow(ScenarioNotFoundException::new);
-//
-//		Place place = Place.create(request.getGooglePlaceId(),
-//							   request.getPlaceName(),
-//							   request.getPlaceAddress(),
-//							   request.getPlaceDescription(),
-//							   request.getLatitude(),
-//							   request.getLongitude(),
-//							   scenarioEntity,
-//							   regionEntity
-//							   );
-//
-//		placeRepository.save(place);
-//	}
-//
-//	// 장소 조회
-//	@Transactional(readOnly = true)
-//	public AdminReadPlaceDto.ResponseRead readPlace(AdminReadPlaceDto.RequestRead request) {
-//
-//		Long placeId = request.getPlaceId();
-//
-//		Place place = placeRepository.findById(placeId)
-//				.orElseThrow(PlaceNotFoundException::new);
-//
-//		AdminReadPlaceDto.ResponseRead response = AdminReadPlaceDto.ResponseRead.from(place);
-//
-//		return response;
-//	}
-//
-//	// 장소 수정
-//	@Transactional
-//	public void updatePlace(Long placeId, AdminUpdatePlaceDto.RequestUpdate request) {
-//
-//		Place place = placeRepository.findById(placeId)
-//				.orElseThrow(PlaceNotFoundException::new);
-//
-//		Long scenarioId = request.getScenarioId();
-//
-//		Scenario scenario = scenarioRepository.findById(scenarioId)
-//				.orElseThrow(ScenarioNotFoundException::new);
-//
-//		place.update(request.getPlaceName(),
-//				 request.getPlaceDescription(),
-//				 scenario);
-//	}
-//}
+
+package kr.co.mapspring.place.service;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.mapspring.global.exception.place.PlaceAlreadyExistsException;
+import kr.co.mapspring.global.exception.place.PlaceNotFoundException;
+import kr.co.mapspring.global.exception.place.RegionNotFoundException;
+import kr.co.mapspring.global.exception.place.ScenarioNotFoundException;
+import kr.co.mapspring.place.dto.AdminCreatePlaceDto;
+import kr.co.mapspring.place.dto.AdminReadPlaceDto;
+import kr.co.mapspring.place.entity.Place;
+import kr.co.mapspring.place.entity.Region;
+import kr.co.mapspring.place.entity.Scenario;
+import kr.co.mapspring.place.repository.PlaceRepository;
+import kr.co.mapspring.place.repository.RegionRepository;
+import kr.co.mapspring.place.repository.ScenarioRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPlaceService {
+
+	private final PlaceRepository placeRepository;
+	private final RegionRepository regionRepository;
+	private final ScenarioRepository scenarioRepository;
+
+	// 장소 생성
+	@Transactional
+	public void savePlace(AdminCreatePlaceDto.RequestCreate request) {
+
+		Long regionId = request.getRegionId();
+		Long scenarioId = request.getScenarioId();
+		String googlePlaceId = request.getGooglePlaceId();
+
+		boolean placeExists = placeRepository.existsByGooglePlaceId(googlePlaceId);
+
+		if (placeExists) {
+			throw new PlaceAlreadyExistsException();
+		}
+
+		Region regionEntity = regionRepository.findById(regionId)
+				.orElseThrow(RegionNotFoundException::new);
+
+		Scenario scenarioEntity = scenarioRepository.findById(scenarioId)
+				.orElseThrow(ScenarioNotFoundException::new);
+
+		Place place = Place.create(request.getGooglePlaceId(),
+							   request.getPlaceName(),
+							   request.getPlaceAddress(),
+							   request.getPlaceDescription(),
+							   request.getLatitude(),
+							   request.getLongitude(),
+							   scenarioEntity,
+							   regionEntity
+							   );
+
+		placeRepository.save(place);
+	}
+
+	// 장소 조회
+	@Transactional(readOnly = true)
+	public AdminReadPlaceDto.ResponseRead readPlace(AdminReadPlaceDto.RequestRead request) {
+
+		Long placeId = request.getPlaceId();
+
+		Place place = placeRepository.findById(placeId)
+				.orElseThrow(PlaceNotFoundException::new);
+
+		AdminReadPlaceDto.ResponseRead response = AdminReadPlaceDto.ResponseRead.from(place);
+
+		return response;
+	}
+
+	// 장소 수정
+	@Transactional
+	public void updatePlace(Long placeId, AdminUpdatePlaceDto.RequestUpdate request) {
+
+		Place place = placeRepository.findById(placeId)
+				.orElseThrow(PlaceNotFoundException::new);
+
+		Long scenarioId = request.getScenarioId();
+
+		Scenario scenario = scenarioRepository.findById(scenarioId)
+				.orElseThrow(ScenarioNotFoundException::new);
+
+		place.update(request.getPlaceName(),
+				 request.getPlaceDescription(),
+				 scenario);
+	}
+}

--- a/src/test/java/kr/co/mapspring/learning/service/LearningServiceTest.java
+++ b/src/test/java/kr/co/mapspring/learning/service/LearningServiceTest.java
@@ -1,0 +1,79 @@
+package kr.co.mapspring.learning.service;
+
+import kr.co.mapspring.learning.entity.StudyLog;
+import kr.co.mapspring.learning.entity.StudyScore;
+import kr.co.mapspring.learning.enums.StudyType;
+import kr.co.mapspring.learning.repository.StudyLogRepository;
+import kr.co.mapspring.learning.repository.StudyScoreRepository;
+import kr.co.mapspring.learning.service.impl.LearningServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LearningServiceTest {
+
+    @Mock
+    private StudyLogRepository studyLogRepository;
+
+    @Mock
+    private StudyScoreRepository studyScoreRepository;
+
+    @InjectMocks
+    private LearningServiceImpl learningService;
+
+    @Test
+    @DisplayName("학습 기록과 점수를 정상적으로 저장한다")
+    void 학습_기록과_점수를_정상적으로_저장한다() {
+
+        Long userId = 1L;
+        Long sessionId = 10L;
+        StudyType studyType = StudyType.SCENARIO;
+        Integer earnedExp = 20;
+
+        Integer naturalnessScore = 80;
+        Integer fluencyScore = 70;
+        Integer totalScore = 75;
+
+        given(studyLogRepository.save(any(StudyLog.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        learningService.recordStudyLog(
+                userId,
+                sessionId,
+                studyType,
+                earnedExp,
+                naturalnessScore,
+                fluencyScore,
+                totalScore);
+
+        ArgumentCaptor<StudyLog> studyLogCaptor = ArgumentCaptor.forClass(StudyLog.class);
+        ArgumentCaptor<StudyScore> studyScoreCaptor = ArgumentCaptor.forClass(StudyScore.class);
+
+        verify(studyLogRepository).save(studyLogCaptor.capture());
+        verify(studyScoreRepository).save(studyScoreCaptor.capture());
+
+        StudyLog savedStudyLog = studyLogCaptor.getValue();
+        StudyScore savedStudyScore = studyScoreCaptor.getValue();
+
+        assertEquals(userId, savedStudyLog.getUserId());
+        assertEquals(sessionId, savedStudyLog.getSessionId());
+        assertEquals(studyType, savedStudyLog.getStudyType());
+        assertEquals(earnedExp, savedStudyLog.getEarnedExp());
+
+        assertEquals(savedStudyLog, savedStudyScore.getStudyLog());
+        assertEquals(naturalnessScore, savedStudyScore.getNaturalnessScore());
+        assertEquals(fluencyScore, savedStudyScore.getFluencyScore());
+        assertEquals(totalScore, savedStudyScore.getTotalScore());
+    }
+
+}

--- a/src/test/java/kr/co/mapspring/learning/service/LearningServiceTest.java
+++ b/src/test/java/kr/co/mapspring/learning/service/LearningServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.mapspring.learning.service;
 
 import kr.co.mapspring.learning.entity.StudyLog;
 import kr.co.mapspring.learning.entity.StudyScore;
+import kr.co.mapspring.learning.enums.GoalType;
 import kr.co.mapspring.learning.enums.StudyType;
 import kr.co.mapspring.learning.repository.StudyLogRepository;
 import kr.co.mapspring.learning.repository.StudyScoreRepository;
@@ -27,6 +28,9 @@ class LearningServiceTest {
 
     @Mock
     private StudyScoreRepository studyScoreRepository;
+
+    @Mock
+    private LearningGoalService learningGoalService;
 
     @InjectMocks
     private LearningServiceImpl learningService;
@@ -54,7 +58,8 @@ class LearningServiceTest {
                 earnedExp,
                 naturalnessScore,
                 fluencyScore,
-                totalScore);
+                totalScore
+        );
 
         ArgumentCaptor<StudyLog> studyLogCaptor = ArgumentCaptor.forClass(StudyLog.class);
         ArgumentCaptor<StudyScore> studyScoreCaptor = ArgumentCaptor.forClass(StudyScore.class);
@@ -74,6 +79,8 @@ class LearningServiceTest {
         assertEquals(naturalnessScore, savedStudyScore.getNaturalnessScore());
         assertEquals(fluencyScore, savedStudyScore.getFluencyScore());
         assertEquals(totalScore, savedStudyScore.getTotalScore());
+
+        verify(learningGoalService).updateGoalProgress(userId, GoalType.STUDY_COUNT, 1);
     }
 
 }

--- a/src/test/java/kr/co/mapspring/place/service/AdminPlaceServiceTest.java
+++ b/src/test/java/kr/co/mapspring/place/service/AdminPlaceServiceTest.java
@@ -124,7 +124,7 @@ class AdminPlaceServiceTest {
         assertThrows(RegionNotFoundException.class, () -> adminPlaceService.savePlace(request));
         verify(placeRepository, never()).save(any(Place.class));
     }
-    
+
     @Test
     @DisplayName("장소 저장 실패 존재하지 않는 시나리오")
     void 장소_저장_실패_존재하지_않는_시나리오() {
@@ -154,7 +154,7 @@ class AdminPlaceServiceTest {
         assertThrows(ScenarioNotFoundException.class, () -> adminPlaceService.savePlace(request));
         verify(placeRepository, never()).save(any(Place.class));
     }
-    
+
     @Test
     @DisplayName("장소 조회 성공")
     void 장소_조회_성공() {
@@ -167,14 +167,14 @@ class AdminPlaceServiceTest {
 
         Scenario scenario = Scenario.withId(20L);
 
-        Place place = Place.testOf(1L, 
+        Place place = Place.testOf(1L,
         					   "google-place-123",
         					   "스타벅스 강남점",
         					   "인천시 서구",
-        					   "커피를 주문할 수 있는 장소", 
-        					   new BigDecimal("37.12345678"), 
-        					   new BigDecimal("127.12345678"), 
-        					   region, 
+        					   "커피를 주문할 수 있는 장소",
+        					   new BigDecimal("37.12345678"),
+        					   new BigDecimal("127.12345678"),
+        					   region,
         					   scenario);
 
         when(placeRepository.findById(request.getPlaceId()))
@@ -206,7 +206,7 @@ class AdminPlaceServiceTest {
         // when & then
         assertThrows(PlaceNotFoundException.class, () -> adminPlaceService.readPlace(request));
     }
-    
+
     @Test
     @DisplayName("장소 수정 성공")
     void 장소_수정_성공() {


### PR DESCRIPTION
## 작업내용
- 학습 목표 선택, 해제, 조회 API 구현
- 학습 기록(StudyLog) 및 점수(StudyScore) 저장 기능 구현
- 학습 완료 시 목표 진행도 업데이트 로직 추가
- Swagger 문서 작성 및 API 응답 구조 개선(ErrorCode 추가)

## 변경사항
- LearningGoalController.java 생성
- LearningGoalControllerDocs.java 생성 (Swagger 문서 분리)
- LearningGoalDto.java 생성
- LearningServiceImpl.java 수정 (학습 기록 + 목표 진행도 연동)
- StudyLog / StudyScore 엔티티 및 Repository 추가
- ErrorCode enum에 LearningGoal 관련 코드 추가
- ApiResponseDTO 구조 개선 (code 필드 추가)

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [v] 로컬 테스트 완료
- [v] Postman API 테스트 완료
- [v] Swagger UI 확인 완료
<img width="1205" height="1020" alt="image" src="https://github.com/user-attachments/assets/4536fe60-91b1-454c-8ac3-0b259d08c38f" />


## 참고사항
- IntelliJ로 커밋 시 커밋 메시지가 깨지는 점 양해부탁드립니다ㅠ (이 부분 해결해보겠습니다.)
- 학습 기록 조회 API는 마이페이지/학습 프로필 화면에서 활용될 수 있어 함께 구현했습니다.
- 해당 화면은 타 팀원 담당 영역이므로, 추후 마이페이지 구현 시 응답 필드나 조회 조건은 담당자와 협의하여 수정될 수 있습니다.
- 현재는 StudyLog + StudyScore 기준의 기본 조회 형태로 구현했습니다.

- 학습 목표 API 테스트를 위해 아래 더미데이터를 DB에 추가해야 합니다.

```sql
INSERT INTO goal_master
(goal_type, goal_title, goal_description, target_value, period_type, is_active, created_at, updated_at)
VALUES
('STUDY_COUNT', '하루 1회 학습', '하루에 한 번 학습하기', 1, 'DAILY', true, NOW(), NOW()),
('STUDY_COUNT', '주간 5회 학습', '일주일에 다섯 번 학습하기', 5, 'WEEKLY', true, NOW(), NOW());