### PR TITLE
feat(user): 회원가입 2차 약관동의 기능 추가 완료 및 API 정리 및  Swagger , docs 문서화 작업 완료 / 회원가입 로직 완성

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 	//User 회원가입용
 	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 	PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+	PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 전화번호입니다."),
 	
 	//User 약관동의용
 	SERVICE_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "서비스 이용약관 동의는 필수입니다."),

--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -20,8 +20,12 @@ public enum ErrorCode {
 	
 	//User 회원가입용
 	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
-	PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+	PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 	
+	//User 약관동의용
+	SERVICE_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "서비스 이용약관 동의는 필수입니다."),
+	PRIVACY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "개인정보 수집 및 이용 동의는 필수입니다."),
+	TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "활성 약관 정보를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/kr/co/mapspring/global/exception/user/PhoneNumberAlreadyExistsException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/user/PhoneNumberAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package kr.co.mapspring.global.exception.user;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class PhoneNumberAlreadyExistsException extends CustomException {
+    public PhoneNumberAlreadyExistsException() {
+        super(ErrorCode.PHONE_NUMBER_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/kr/co/mapspring/global/exception/user/PrivacyTermsRequiredException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/user/PrivacyTermsRequiredException.java
@@ -1,0 +1,11 @@
+package kr.co.mapspring.global.exception.user;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class PrivacyTermsRequiredException extends CustomException {
+
+    public PrivacyTermsRequiredException() {
+        super(ErrorCode.PRIVACY_TERMS_REQUIRED);
+    }
+}

--- a/src/main/java/kr/co/mapspring/global/exception/user/ServiceTermsRequiredException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/user/ServiceTermsRequiredException.java
@@ -1,0 +1,11 @@
+package kr.co.mapspring.global.exception.user;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class ServiceTermsRequiredException extends CustomException {
+
+    public ServiceTermsRequiredException() {
+        super(ErrorCode.SERVICE_TERMS_REQUIRED);
+    }
+}

--- a/src/main/java/kr/co/mapspring/global/exception/user/TermsNotFoundException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/user/TermsNotFoundException.java
@@ -1,0 +1,11 @@
+package kr.co.mapspring.global.exception.user;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class TermsNotFoundException extends CustomException {
+
+    public TermsNotFoundException() {
+        super(ErrorCode.TERMS_NOT_FOUND);
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
@@ -92,10 +92,10 @@ public interface AuthControllerDocs {
             )
             LoginDto.RequestLogin request
     );
-    
+
     @Operation(
             summary = "회원가입",
-            description = "이름, 생년월일, 주소, 전화번호, 이메일, 비밀번호를 입력받아 회원가입을 처리합니다."
+            description = "이름, 생년월일, 주소, 전화번호, 이메일, 비밀번호 및 약관 동의 여부를 입력받아 회원가입을 처리합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원가입 성공"),
@@ -132,6 +132,57 @@ public interface AuthControllerDocs {
                                             """
                             )
                     )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "생년월일 형식 오류 또는 요청 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "입력값 검증 실패",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "서비스 이용약관 미동의",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "서비스 이용약관 동의는 필수입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "개인정보 수집 및 이용 미동의",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "개인정보 수집 및 이용 동의는 필수입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
             )
     })
     ApiResponseDTO<SignUpDto.ResponseSignUp> signUp(
@@ -150,7 +201,10 @@ public interface AuthControllerDocs {
                                               "phoneNumber": "010-1234-5678",
                                               "email": "test@naver.com",
                                               "password": "1234",
-                                              "passwordConfirm": "1234"
+                                              "passwordConfirm": "1234",
+                                              "serviceAgree": true,
+                                              "privacyAgree": true,
+                                              "marketingAgree": false
                                             }
                                             """
                             )

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
@@ -117,6 +117,23 @@ public interface AuthControllerDocs {
                     )
             ),
             @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 존재하는 전화번호",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 409,
+                                              "message": "이미 존재하는 전화번호입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "400",
                     description = "비밀번호 확인 불일치",
                     content = @Content(
@@ -192,22 +209,22 @@ public interface AuthControllerDocs {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = SignUpDto.RequestSignUp.class),
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "name": "홍길동",
-                                              "birthDate": "2000-01-01",
-                                              "address": "서울시 강남구",
-                                              "phoneNumber": "010-1234-5678",
-                                              "email": "test@naver.com",
-                                              "password": "1234",
-                                              "passwordConfirm": "1234",
-                                              "serviceAgree": true,
-                                              "privacyAgree": true,
-                                              "marketingAgree": false
-                                            }
-                                            """
-                            )
+                            		examples = @ExampleObject(
+                            		        value = """
+                            		                {
+                            		                  "name": "홍길동",
+                            		                  "birthDate": "2000-01-01",
+                            		                  "address": "서울시 강남구",
+                            		                  "phoneNumber": "010-1234-5678",
+                            		                  "email": "test@naver.com",
+                            		                  "password": "1234",
+                            		                  "passwordConfirm": "1234",
+                            		                  "serviceAgree": true,
+                            		                  "privacyAgree": true,
+                            		                  "marketingAgree": false
+                            		                }
+                            		                """
+                            		)
                     )
             )
             SignUpDto.RequestSignUp request

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
@@ -152,7 +152,7 @@ public interface AuthControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "생년월일 형식 오류 또는 요청 형식 오류",
+                    description = "입력값 검증 실패",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
@@ -200,6 +200,23 @@ public interface AuthControllerDocs {
                                             """
                             )
                     )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "활성 약관 정보 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 404,
+                                              "message": "활성 약관 정보를 찾을 수 없습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
             )
     })
     ApiResponseDTO<SignUpDto.ResponseSignUp> signUp(
@@ -209,22 +226,22 @@ public interface AuthControllerDocs {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = SignUpDto.RequestSignUp.class),
-                            		examples = @ExampleObject(
-                            		        value = """
-                            		                {
-                            		                  "name": "홍길동",
-                            		                  "birthDate": "2000-01-01",
-                            		                  "address": "서울시 강남구",
-                            		                  "phoneNumber": "010-1234-5678",
-                            		                  "email": "test@naver.com",
-                            		                  "password": "1234",
-                            		                  "passwordConfirm": "1234",
-                            		                  "serviceAgree": true,
-                            		                  "privacyAgree": true,
-                            		                  "marketingAgree": false
-                            		                }
-                            		                """
-                            		)
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "name": "홍길동",
+                                              "birthDate": "2000-01-01",
+                                              "address": "서울시 강남구",
+                                              "phoneNumber": "010-0000-0001",
+                                              "email": "test@test1.com",
+                                              "password": "1234",
+                                              "passwordConfirm": "1234",
+                                              "serviceAgree": true,
+                                              "privacyAgree": true,
+                                              "marketingAgree": false
+                                            }
+                                            """
+                            )
                     )
             )
             SignUpDto.RequestSignUp request

--- a/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
@@ -47,6 +47,15 @@ public class SignUpDto {
     	@NotBlank
         @Schema(description = "비밀번호 확인", example = "1234")
         private String passwordConfirm;
+    	
+    	@Schema(description = "서비스 이용약관 동의 여부", example = "true")
+        private Boolean serviceAgree;
+
+        @Schema(description = "개인정보 수집 및 이용 동의 여부", example = "true")
+        private Boolean privacyAgree;
+
+        @Schema(description = "마케팅 정보 수신 동의 여부", example = "false")
+        private Boolean marketingAgree;
     }
 
     @Getter

--- a/src/main/java/kr/co/mapspring/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/mapspring/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     
     boolean existsByEmail(String email);
+    
+    boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/kr/co/mapspring/user/service/SignUpService.java
+++ b/src/main/java/kr/co/mapspring/user/service/SignUpService.java
@@ -3,7 +3,5 @@ package kr.co.mapspring.user.service;
 import kr.co.mapspring.user.dto.SignUpDto;
 
 public interface SignUpService {
-	
     SignUpDto.ResponseSignUp signUp(SignUpDto.RequestSignUp request);
-
 }

--- a/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
@@ -6,10 +6,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.co.mapspring.global.exception.user.EmailAlreadyExistsException;
 import kr.co.mapspring.global.exception.user.PasswordConfirmMismatchException;
+import kr.co.mapspring.global.exception.user.PrivacyTermsRequiredException;
+import kr.co.mapspring.global.exception.user.ServiceTermsRequiredException;
+import kr.co.mapspring.global.exception.user.TermsNotFoundException;
 import kr.co.mapspring.user.dto.SignUpDto;
 import kr.co.mapspring.user.entity.User;
 import kr.co.mapspring.user.repository.UserRepository;
 import kr.co.mapspring.user.service.SignUpService;
+import kr.co.mapspring.user.terms.entity.Terms;
+import kr.co.mapspring.user.terms.entity.UserTermsAgreement;
+import kr.co.mapspring.user.terms.enums.TermsType;
+import kr.co.mapspring.user.terms.repository.TermsRepository;
+import kr.co.mapspring.user.terms.repository.UserTermsAgreementRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -20,23 +28,28 @@ public class SignUpServiceImpl implements SignUpService {
 
     private final PasswordEncoder passwordEncoder;
 
+    private final TermsRepository termsRepository;
+
+    private final UserTermsAgreementRepository userTermsAgreementRepository;
+
     @Override
     @Transactional
     public SignUpDto.ResponseSignUp signUp(SignUpDto.RequestSignUp request) {
         if (userRepository.existsByEmail(request.getEmail())) {
-        	throw new EmailAlreadyExistsException();
+            throw new EmailAlreadyExistsException();
         }
 
         if (!request.getPassword().equals(request.getPasswordConfirm())) {
-        	throw new PasswordConfirmMismatchException();
+            throw new PasswordConfirmMismatchException();
         }
+
+        validateRequiredTerms(request);
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-
         User user = User.create(
                 request.getEmail(),
-                request.getName(), 	
+                request.getName(),
                 request.getBirthDate(),
                 request.getAddress(),
                 request.getPhoneNumber(),
@@ -45,6 +58,39 @@ public class SignUpServiceImpl implements SignUpService {
 
         User savedUser = userRepository.save(user);
 
+        Terms serviceTerms = getActiveTerms(TermsType.SERVICE);
+        Terms privacyTerms = getActiveTerms(TermsType.PRIVACY);
+        Terms marketingTerms = getActiveTerms(TermsType.MARKETING);
+
+        saveTermsAgreement(savedUser, serviceTerms, request.getServiceAgree());
+        saveTermsAgreement(savedUser, privacyTerms, request.getPrivacyAgree());
+        saveTermsAgreement(savedUser, marketingTerms, request.getMarketingAgree());
+
         return SignUpDto.ResponseSignUp.from(savedUser);
+    }
+
+    private void validateRequiredTerms(SignUpDto.RequestSignUp request) {
+        if (!Boolean.TRUE.equals(request.getServiceAgree())) {
+            throw new ServiceTermsRequiredException();
+        }
+
+        if (!Boolean.TRUE.equals(request.getPrivacyAgree())) {
+            throw new PrivacyTermsRequiredException();
+        }
+    }
+
+    private Terms getActiveTerms(TermsType termsType) {
+        return termsRepository.findByTypeAndActiveTrue(termsType)
+                .orElseThrow(TermsNotFoundException::new);
+    }
+
+    private void saveTermsAgreement(User user, Terms term, Boolean agreed) {
+        UserTermsAgreement agreement = UserTermsAgreement.create(
+                user,
+                term,
+                Boolean.TRUE.equals(agreed)
+        );
+
+        userTermsAgreementRepository.save(agreement);
     }
 }

--- a/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
@@ -80,7 +80,7 @@ public class SignUpServiceImpl implements SignUpService {
     }
 
     private Terms getActiveTerms(TermsType termsType) {
-        return termsRepository.findByTypeAndActiveTrue(termsType)
+        return termsRepository.findByTermTypeAndActiveTrue(termsType)
                 .orElseThrow(TermsNotFoundException::new);
     }
 

--- a/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/SignUpServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.co.mapspring.global.exception.user.EmailAlreadyExistsException;
 import kr.co.mapspring.global.exception.user.PasswordConfirmMismatchException;
+import kr.co.mapspring.global.exception.user.PhoneNumberAlreadyExistsException;
 import kr.co.mapspring.global.exception.user.PrivacyTermsRequiredException;
 import kr.co.mapspring.global.exception.user.ServiceTermsRequiredException;
 import kr.co.mapspring.global.exception.user.TermsNotFoundException;
@@ -37,6 +38,10 @@ public class SignUpServiceImpl implements SignUpService {
     public SignUpDto.ResponseSignUp signUp(SignUpDto.RequestSignUp request) {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new EmailAlreadyExistsException();
+        }
+        
+        if (userRepository.existsByPhoneNumber(request.getPhoneNumber())) {
+            throw new PhoneNumberAlreadyExistsException();
         }
 
         if (!request.getPassword().equals(request.getPasswordConfirm())) {

--- a/src/main/java/kr/co/mapspring/user/terms/entity/Term.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/Term.java
@@ -66,4 +66,12 @@ public class Term {
         this.updatedAt = LocalDateTime.now();
     }
     
+    public boolean isActive() {
+        return this.active;
+    }
+
+    public boolean isRequired() {
+        return this.required;
+    }
+    
 }

--- a/src/main/java/kr/co/mapspring/user/terms/entity/Terms.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/Terms.java
@@ -13,7 +13,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
-import kr.co.mapspring.user.terms.enums.TermType;
+import kr.co.mapspring.user.terms.enums.TermsType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "terms")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Term {
+public class Terms {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "term_id", nullable = false, updatable = false)
@@ -40,7 +40,7 @@ public class Term {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "term_type", nullable = false, length = 30)
-    private TermType termType;
+    private TermsType termType;
 
     @Column(name = "is_required", nullable = false)
     private boolean required;

--- a/src/main/java/kr/co/mapspring/user/terms/entity/Terms.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/Terms.java
@@ -15,6 +15,7 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import kr.co.mapspring.user.terms.enums.TermsType;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -53,6 +54,26 @@ public class Terms {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+    
+    // 테스트용 코드
+    @Builder
+    private Terms(
+            Long termId,
+            String title,
+            String content,
+            String version,
+            TermsType type,
+            boolean required,
+            boolean active
+    ) {
+        this.termId = termId;
+        this.title = title;
+        this.content = content;
+        this.version = version;
+        this.termType = type;
+        this.required = required;
+        this.active = active;
+    }
     
     @PrePersist
     protected void prePersist() {

--- a/src/main/java/kr/co/mapspring/user/terms/entity/UserTermsAgreement.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/UserTermsAgreement.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 	)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserTermAgreement {
+public class UserTermsAgreement {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,7 +40,7 @@ public class UserTermAgreement {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "term_id", nullable = false)
-    private Term term;
+    private Terms term;
 
     @Column(name = "agreed", nullable = false)
     private boolean agreed;
@@ -53,9 +53,15 @@ public class UserTermAgreement {
     
     @PrePersist
     protected void prePersist() {
-        if (this.agreedAt == null) {
-            this.agreedAt = LocalDateTime.now();
-        }
         this.createdAt = LocalDateTime.now();
+    }
+
+    public static UserTermsAgreement create(User user, Terms term, boolean agreed) {
+        UserTermsAgreement agreement = new UserTermsAgreement();
+        agreement.user = user;
+        agreement.term = term;
+        agreement.agreed = agreed;
+        agreement.agreedAt = agreed ? LocalDateTime.now() : null;
+        return agreement;
     }
 }

--- a/src/main/java/kr/co/mapspring/user/terms/entity/UserTermsAgreement.java
+++ b/src/main/java/kr/co/mapspring/user/terms/entity/UserTermsAgreement.java
@@ -61,7 +61,7 @@ public class UserTermsAgreement {
         agreement.user = user;
         agreement.term = term;
         agreement.agreed = agreed;
-        agreement.agreedAt = agreed ? LocalDateTime.now() : null;
+        agreement.agreedAt = LocalDateTime.now();
         return agreement;
     }
 }

--- a/src/main/java/kr/co/mapspring/user/terms/enums/TermsType.java
+++ b/src/main/java/kr/co/mapspring/user/terms/enums/TermsType.java
@@ -1,6 +1,6 @@
 package kr.co.mapspring.user.terms.enums;
 
-public enum TermType {
+public enum TermsType {
     SERVICE,
     PRIVACY,
     MARKETING

--- a/src/main/java/kr/co/mapspring/user/terms/repository/TermsRepository.java
+++ b/src/main/java/kr/co/mapspring/user/terms/repository/TermsRepository.java
@@ -11,8 +11,7 @@ import kr.co.mapspring.user.terms.enums.TermsType;
 public interface TermsRepository extends JpaRepository<Terms, Long> {
 
     // 활성화된 특정 타입의 약관 1개 조회
-    Optional<Terms> findByTypeAndActiveTrue(TermsType type);
-
+	Optional<Terms> findByTermTypeAndActiveTrue(TermsType termType);
     // 현재 활성화된 약관 전체 조회
     List<Terms> findAllByActiveTrue();
 }

--- a/src/main/java/kr/co/mapspring/user/terms/repository/TermsRepository.java
+++ b/src/main/java/kr/co/mapspring/user/terms/repository/TermsRepository.java
@@ -1,0 +1,18 @@
+package kr.co.mapspring.user.terms.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.mapspring.user.terms.entity.Terms;
+import kr.co.mapspring.user.terms.enums.TermsType;
+
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+    // 활성화된 특정 타입의 약관 1개 조회
+    Optional<Terms> findByTypeAndActiveTrue(TermsType type);
+
+    // 현재 활성화된 약관 전체 조회
+    List<Terms> findAllByActiveTrue();
+}

--- a/src/main/java/kr/co/mapspring/user/terms/repository/UserTermsAgreementRepository.java
+++ b/src/main/java/kr/co/mapspring/user/terms/repository/UserTermsAgreementRepository.java
@@ -1,0 +1,8 @@
+package kr.co.mapspring.user.terms.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.mapspring.user.terms.entity.UserTermsAgreement;
+
+public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, Long> {
+}

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -279,6 +279,68 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.message").value("비밀번호와 비밀번호 확인이 일치하지 않습니다."));
     }
     
+    @Test
+    @DisplayName("서비스 이용약관에 동의하지 않으면 400 실패 응답을 반환한다")
+    void signUpFailWhenServiceTermsNotAgreed() throws Exception {
+        // given
+        given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+                .willThrow(new CustomException(ErrorCode.SERVICE_TERMS_REQUIRED));
+
+        String requestBody = """
+                {
+                  "name": "홍길동",
+                  "birthDate": "2000-01-01",
+                  "address": "서울시 강남구",
+                  "phoneNumber": "010-1234-5678",
+                  "email": "test@naver.com",
+                  "password": "1234",
+                  "passwordConfirm": "1234",
+                  "serviceAgree": false,
+                  "privacyAgree": true,
+                  "marketingAgree": false
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("서비스 이용약관 동의는 필수입니다."));
+    }
     
+    @Test
+    @DisplayName("개인정보 수집 및 이용에 동의하지 않으면 400 실패 응답을 반환한다")
+    void signUpFailWhenPrivacyTermsNotAgreed() throws Exception {
+        // given
+        given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+                .willThrow(new CustomException(ErrorCode.PRIVACY_TERMS_REQUIRED));
+
+        String requestBody = """
+                {
+                  "name": "홍길동",
+                  "birthDate": "2000-01-01",
+                  "address": "서울시 강남구",
+                  "phoneNumber": "010-1234-5678",
+                  "email": "test@naver.com",
+                  "password": "1234",
+                  "passwordConfirm": "1234",
+                  "serviceAgree": true,
+                  "privacyAgree": false,
+                  "marketingAgree": false
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("개인정보 수집 및 이용 동의는 필수입니다."));
+    }
     
 }

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -149,17 +149,20 @@ class AuthControllerTest {
     @DisplayName("생년월일 형식이 올바르지 않으면 400 실패 응답을 반환한다")
     void signUpFailWhenBirthDateFormatIsInvalid() throws Exception {
         // given
-        String requestBody = """
-                {
-                  "name": "홍길동",
-                  "birthDate": "2000/01/01",
-                  "address": "서울시 강남구",
-                  "phoneNumber": "010-1234-5678",
-                  "email": "test@naver.com",
-                  "password": "1234",
-                  "passwordConfirm": "1234"
-                }
-                """;
+    	String requestBody = """
+    	        {
+    	          "name": "홍길동",
+    	          "birthDate": "2000/01/01",
+    	          "address": "서울시 강남구",
+    	          "phoneNumber": "010-1234-5678",
+    	          "email": "test@naver.com",
+    	          "password": "1234",
+    	          "passwordConfirm": "1234",
+    	          "serviceAgree": true,
+    	          "privacyAgree": true,
+    	          "marketingAgree": false
+    	        }
+    	        """;
 
         // when & then
         mockMvc.perform(post("/api/auth/signup")
@@ -192,7 +195,10 @@ class AuthControllerTest {
                   "phoneNumber": "010-1234-5678",
                   "email": "test@naver.com",
                   "password": "1234",
-                  "passwordConfirm": "1234"
+                  "passwordConfirm": "1234",
+                  "serviceAgree": true,
+                  "privacyAgree": true,
+                  "marketingAgree": false
                 }
                 """;
 
@@ -224,7 +230,10 @@ class AuthControllerTest {
                   "phoneNumber": "010-1234-5678",
                   "email": "test@naver.com",
                   "password": "1234",
-                  "passwordConfirm": "1234"
+                  "passwordConfirm": "1234",
+                  "serviceAgree": true,
+                  "privacyAgree": true,
+                  "marketingAgree": false
                 }
                 """;
 
@@ -253,7 +262,10 @@ class AuthControllerTest {
                   "phoneNumber": "010-1234-5678",
                   "email": "test@naver.com",
                   "password": "1234",
-                  "passwordConfirm": "4321"
+                  "passwordConfirm": "4321",
+                  "serviceAgree": true,
+                  "privacyAgree": true,
+                  "marketingAgree": false
                 }
                 """;
 

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -32,9 +32,11 @@ class AuthControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    // 로그인 서비스 mock
     @MockitoBean
     private LoginService loginService;
 
+    // 회원가입 서비스 mock
     @MockitoBean
     private SignUpService signUpService;
 
@@ -74,7 +76,7 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 이메일이면 404 실패 응답을 반환한다")
+    @DisplayName("로그인 시 존재하지 않는 이메일이면 404 실패 응답을 반환한다")
     void loginFailWhenUserNotFound() throws Exception {
         // given
         given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
@@ -98,7 +100,7 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("비밀번호가 일치하지 않으면 401 실패 응답을 반환한다")
+    @DisplayName("로그인 시 비밀번호가 일치하지 않으면 401 실패 응답을 반환한다")
     void loginFailWhenPasswordInvalid() throws Exception {
         // given
         given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
@@ -122,7 +124,7 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("사용자 상태가 ACTIVE가 아니면 403 실패 응답을 반환한다")
+    @DisplayName("로그인 시 사용자 상태가 ACTIVE가 아니면 403 실패 응답을 반환한다")
     void loginFailWhenInactiveUser() throws Exception {
         // given
         given(loginService.login(ArgumentMatchers.any(LoginDto.RequestLogin.class)))
@@ -146,34 +148,6 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("생년월일 형식이 올바르지 않으면 400 실패 응답을 반환한다")
-    void signUpFailWhenBirthDateFormatIsInvalid() throws Exception {
-        // given
-    	String requestBody = """
-    	        {
-    	          "name": "홍길동",
-    	          "birthDate": "2000/01/01",
-    	          "address": "서울시 강남구",
-    	          "phoneNumber": "010-1234-5678",
-    	          "email": "test@naver.com",
-    	          "password": "1234",
-    	          "passwordConfirm": "1234",
-    	          "serviceAgree": true,
-    	          "privacyAgree": true,
-    	          "marketingAgree": false
-    	        }
-    	        """;
-
-        // when & then
-        mockMvc.perform(post("/api/auth/signup")
-                        .contentType(APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.message").value("입력값 검증 실패"));
-    }
-    @Test
     @DisplayName("회원가입 요청이 성공하면 공통 성공 응답을 반환한다")
     void signUpSuccess() throws Exception {
         // given
@@ -183,8 +157,7 @@ class AuthControllerTest {
                 .name("홍길동")
                 .build();
 
-        // 회원가입 서비스가 성공 응답을 반환한다고 가정한다.
-        given(signUpService.signUp(org.mockito.ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+        given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
                 .willReturn(response);
 
         String requestBody = """
@@ -192,8 +165,8 @@ class AuthControllerTest {
                   "name": "홍길동",
                   "birthDate": "2000-01-01",
                   "address": "서울시 강남구",
-                  "phoneNumber": "010-1234-5678",
-                  "email": "test@naver.com",
+                  "phoneNumber": "010-9000-0001",
+                  "email": "sample_signup_success@naver.com",
                   "password": "1234",
                   "passwordConfirm": "1234",
                   "serviceAgree": true,
@@ -216,19 +189,19 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("이미 존재하는 이메일이면 409 실패 응답을 반환한다")
+    @DisplayName("회원가입 시 이미 존재하는 이메일이면 409 실패 응답을 반환한다")
     void signUpFailWhenEmailAlreadyExists() throws Exception {
         // given
-        given(signUpService.signUp(org.mockito.ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
-                .willThrow(new kr.co.mapspring.global.exception.user.EmailAlreadyExistsException());
+        given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+                .willThrow(new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS));
 
         String requestBody = """
                 {
                   "name": "홍길동",
                   "birthDate": "2000-01-01",
                   "address": "서울시 강남구",
-                  "phoneNumber": "010-1234-5678",
-                  "email": "test@naver.com",
+                  "phoneNumber": "010-9000-0002",
+                  "email": "sample_signup_dup_email@naver.com",
                   "password": "1234",
                   "passwordConfirm": "1234",
                   "serviceAgree": true,
@@ -246,9 +219,9 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message").value("이미 존재하는 이메일입니다."));
     }
-    
+
     @Test
-    @DisplayName("이미 존재하는 전화번호이면 409 실패 응답을 반환한다")
+    @DisplayName("회원가입 시 이미 존재하는 전화번호이면 409 실패 응답을 반환한다")
     void signUpFailWhenPhoneNumberAlreadyExists() throws Exception {
         // given
         given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
@@ -260,7 +233,7 @@ class AuthControllerTest {
                   "birthDate": "2000-01-01",
                   "address": "서울시 강남구",
                   "phoneNumber": "010-1234-5678",
-                  "email": "test@naver.com",
+                  "email": "sample_signup_dup_phone@naver.com",
                   "password": "1234",
                   "passwordConfirm": "1234",
                   "serviceAgree": true,
@@ -280,19 +253,19 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("비밀번호 확인이 일치하지 않으면 400 실패 응답을 반환한다")
+    @DisplayName("회원가입 시 비밀번호 확인이 일치하지 않으면 400 실패 응답을 반환한다")
     void signUpFailWhenPasswordConfirmDoesNotMatch() throws Exception {
         // given
-        given(signUpService.signUp(org.mockito.ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
-                .willThrow(new kr.co.mapspring.global.exception.user.PasswordConfirmMismatchException());
+        given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+                .willThrow(new CustomException(ErrorCode.PASSWORD_CONFIRM_MISMATCH));
 
         String requestBody = """
                 {
                   "name": "홍길동",
                   "birthDate": "2000-01-01",
                   "address": "서울시 강남구",
-                  "phoneNumber": "010-1234-5678",
-                  "email": "test@naver.com",
+                  "phoneNumber": "010-9000-0003",
+                  "email": "sample_signup_password_confirm@naver.com",
                   "password": "1234",
                   "passwordConfirm": "4321",
                   "serviceAgree": true,
@@ -310,9 +283,38 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("비밀번호와 비밀번호 확인이 일치하지 않습니다."));
     }
-    
+
     @Test
-    @DisplayName("서비스 이용약관에 동의하지 않으면 400 실패 응답을 반환한다")
+    @DisplayName("회원가입 시 생년월일 형식이 올바르지 않으면 400 실패 응답을 반환한다")
+    void signUpFailWhenBirthDateFormatIsInvalid() throws Exception {
+        // given
+        String requestBody = """
+                {
+                  "name": "홍길동",
+                  "birthDate": "2000/01/01",
+                  "address": "서울시 강남구",
+                  "phoneNumber": "010-9000-0004",
+                  "email": "sample_signup_birthdate@naver.com",
+                  "password": "1234",
+                  "passwordConfirm": "1234",
+                  "serviceAgree": true,
+                  "privacyAgree": true,
+                  "marketingAgree": false
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("입력값 검증 실패"));
+    }
+
+    @Test
+    @DisplayName("회원가입 시 서비스 이용약관에 동의하지 않으면 400 실패 응답을 반환한다")
     void signUpFailWhenServiceTermsNotAgreed() throws Exception {
         // given
         given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
@@ -323,8 +325,8 @@ class AuthControllerTest {
                   "name": "홍길동",
                   "birthDate": "2000-01-01",
                   "address": "서울시 강남구",
-                  "phoneNumber": "010-1234-5678",
-                  "email": "test@naver.com",
+                  "phoneNumber": "010-9000-0005",
+                  "email": "sample_signup_service_terms@naver.com",
                   "password": "1234",
                   "passwordConfirm": "1234",
                   "serviceAgree": false,
@@ -342,9 +344,9 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("서비스 이용약관 동의는 필수입니다."));
     }
-    
+
     @Test
-    @DisplayName("개인정보 수집 및 이용에 동의하지 않으면 400 실패 응답을 반환한다")
+    @DisplayName("회원가입 시 개인정보 수집 및 이용에 동의하지 않으면 400 실패 응답을 반환한다")
     void signUpFailWhenPrivacyTermsNotAgreed() throws Exception {
         // given
         given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
@@ -355,8 +357,8 @@ class AuthControllerTest {
                   "name": "홍길동",
                   "birthDate": "2000-01-01",
                   "address": "서울시 강남구",
-                  "phoneNumber": "010-1234-5678",
-                  "email": "test@naver.com",
+                  "phoneNumber": "010-9000-0006",
+                  "email": "sample_signup_privacy_terms@naver.com",
                   "password": "1234",
                   "passwordConfirm": "1234",
                   "serviceAgree": true,
@@ -374,5 +376,4 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("개인정보 수집 및 이용 동의는 필수입니다."));
     }
-    
 }

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -246,6 +246,38 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message").value("이미 존재하는 이메일입니다."));
     }
+    
+    @Test
+    @DisplayName("이미 존재하는 전화번호이면 409 실패 응답을 반환한다")
+    void signUpFailWhenPhoneNumberAlreadyExists() throws Exception {
+        // given
+        given(signUpService.signUp(ArgumentMatchers.any(SignUpDto.RequestSignUp.class)))
+                .willThrow(new CustomException(ErrorCode.PHONE_NUMBER_ALREADY_EXISTS));
+
+        String requestBody = """
+                {
+                  "name": "홍길동",
+                  "birthDate": "2000-01-01",
+                  "address": "서울시 강남구",
+                  "phoneNumber": "010-1234-5678",
+                  "email": "test@naver.com",
+                  "password": "1234",
+                  "passwordConfirm": "1234",
+                  "serviceAgree": true,
+                  "privacyAgree": true,
+                  "marketingAgree": false
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("이미 존재하는 전화번호입니다."));
+    }
 
     @Test
     @DisplayName("비밀번호 확인이 일치하지 않으면 400 실패 응답을 반환한다")

--- a/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
@@ -2,10 +2,12 @@ package kr.co.mapspring.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.CoreMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +25,11 @@ import kr.co.mapspring.user.enums.UserRole;
 import kr.co.mapspring.user.enums.UserStatus;
 import kr.co.mapspring.user.repository.UserRepository;
 import kr.co.mapspring.user.service.impl.SignUpServiceImpl;
+import kr.co.mapspring.user.terms.entity.Terms;
+import kr.co.mapspring.user.terms.entity.UserTermsAgreement;
+import kr.co.mapspring.user.terms.enums.TermsType;
+import kr.co.mapspring.user.terms.repository.TermsRepository;
+import kr.co.mapspring.user.terms.repository.UserTermsAgreementRepository;
 
 @ExtendWith(MockitoExtension.class)
 class SignUpServiceTest {
@@ -35,6 +42,17 @@ class SignUpServiceTest {
 
     @InjectMocks
     private SignUpServiceImpl signUpService;
+    
+    @Mock
+    private TermsRepository termsRepository;
+
+    @Mock
+    private UserTermsAgreementRepository userTermsAgreementRepository;
+    
+    private Terms createTerms(TermsType type, boolean required, boolean active) {
+        // 실제 엔티티 생성 방식에 맞춰 다음 단계에서 맞출 예정
+        return null;
+    }
 
     @Test
     @DisplayName("중복되지 않은 이메일이면 회원가입에 성공한다")
@@ -48,7 +66,10 @@ class SignUpServiceTest {
                 "010-1234-5678",
                 "test@naver.com",
                 "1234",
-                "1234"
+                "1234",
+                true,
+                true,
+                false
         );
 
         // 해당 이메일이 아직 존재하지 않는다고 가정한다.
@@ -98,7 +119,10 @@ class SignUpServiceTest {
                 "010-1234-5678",
                 "test@naver.com",
                 "1234",
-                "1234"
+                "1234",
+                true,
+                true,
+                false
         );
 
         // 해당 이메일이 이미 존재한다고 가정한다.
@@ -125,7 +149,10 @@ class SignUpServiceTest {
                 "010-1234-5678",
                 "test@naver.com",
                 "1234",
-                "4321"
+                "4321",
+                true,
+                true,
+                false
         );
 
         // 이메일은 중복되지 않는다고 가정한다.
@@ -151,7 +178,10 @@ class SignUpServiceTest {
                 "010-1234-5678",
                 "test@naver.com",
                 "1234",
-                "1234"
+                "1234",
+                true,
+                true,
+                false
         );
 
         given(userRepository.existsByEmail("test@naver.com"))
@@ -200,7 +230,10 @@ class SignUpServiceTest {
                 "010-1234-5678",
                 "test@naver.com",
                 "1234",
-                "1234"
+                "1234",
+                true,
+                true,
+                false
         );
 
         given(userRepository.existsByEmail("test@naver.com"))
@@ -237,6 +270,169 @@ class SignUpServiceTest {
                 .isEqualTo(kr.co.mapspring.user.enums.UserStatus.ACTIVE);
         assertThat(capturedUser.getRole())
                 .isEqualTo(kr.co.mapspring.user.enums.UserRole.USER);
+    }
+    
+    @Test
+    @DisplayName("서비스 이용약관에 동의하지 않으면 예외가 발생한다")
+    void signUpFailWhenServiceTermsNotAgreed() {
+        // given
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                LocalDate.of(2000, 1, 1),
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "1234",
+                false,   // serviceAgree
+                true,    // privacyAgree
+                false    // marketingAgree
+        );
+
+        // when & then
+        assertThatThrownBy(() -> signUpService.signUp(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("서비스 이용약관 동의는 필수입니다.");
+    }
+    
+    @Test
+    @DisplayName("개인정보 수집 및 이용에 동의하지 않으면 예외가 발생한다")
+    void signUpFailWhenPrivacyTermsNotAgreed() {
+        // given
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                LocalDate.of(2000, 1, 1),
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "1234",
+                true,    // serviceAgree
+                false,   // privacyAgree
+                false    // marketingAgree
+        );
+
+        // when & then
+        assertThatThrownBy(() -> signUpService.signUp(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("개인정보 수집 및 이용 동의는 필수입니다.");
+    }
+    
+    @Test
+    @DisplayName("마케팅 정보 수신 동의는 선택이므로 false여도 회원가입에 성공한다")
+    void signUpSuccessWhenMarketingAgreeIsFalse() {
+        // given
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                LocalDate.of(2000, 1, 1),
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "1234",
+                true,    // serviceAgree
+                true,    // privacyAgree
+                false    // marketingAgree
+        );
+
+        given(userRepository.existsByEmail("test@naver.com"))
+                .willReturn(false);
+
+        given(passwordEncoder.encode("1234"))
+                .willReturn("encodedPassword");
+
+        User savedUser = User.builder()
+                .userId(1L)
+                .email("test@naver.com")
+                .name("홍길동")
+                .birthDate(LocalDate.of(2000, 1, 1))
+                .address("서울시 강남구")
+                .phoneNumber("010-1234-5678")
+                .passwordHash("encodedPassword")
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.save(any(User.class)))
+                .willReturn(savedUser);
+
+        // 약관 조회 mock
+        Terms serviceTerms = createTerms(TermsType.SERVICE, true, true);
+        Terms privacyTerms = createTerms(TermsType.PRIVACY, true, true);
+        Terms marketingTerms = createTerms(TermsType.MARKETING, false, true);
+
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+                .willReturn(Optional.of(serviceTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+                .willReturn(Optional.of(privacyTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+                .willReturn(Optional.of(marketingTerms));
+
+        // when
+        SignUpDto.ResponseSignUp response = signUpService.signUp(request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUserId()).isEqualTo(1L);
+        assertThat(response.getEmail()).isEqualTo("test@naver.com");
+        assertThat(response.getName()).isEqualTo("홍길동");
+    }
+    
+    @Test
+    @DisplayName("회원가입 성공 시 사용자 약관 동의 이력이 저장된다")
+    void signUpShouldSaveUserTermsAgreements() {
+        // given
+        SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
+                "홍길동",
+                LocalDate.of(2000, 1, 1),
+                "서울시 강남구",
+                "010-1234-5678",
+                "test@naver.com",
+                "1234",
+                "1234",
+                true,    // serviceAgree
+                true,    // privacyAgree
+                false    // marketingAgree
+        );
+
+        given(userRepository.existsByEmail("test@naver.com"))
+                .willReturn(false);
+
+        given(passwordEncoder.encode("1234"))
+                .willReturn("encodedPassword");
+
+        User savedUser = User.builder()
+                .userId(1L)
+                .email("test@naver.com")
+                .name("홍길동")
+                .birthDate(LocalDate.of(2000, 1, 1))
+                .address("서울시 강남구")
+                .phoneNumber("010-1234-5678")
+                .passwordHash("encodedPassword")
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+
+        given(userRepository.save(any(User.class)))
+                .willReturn(savedUser);
+
+        Terms serviceTerms = createTerms(TermsType.SERVICE, true, true);
+        Terms privacyTerms = createTerms(TermsType.PRIVACY, true, true);
+        Terms marketingTerms = createTerms(TermsType.MARKETING, false, true);
+
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+                .willReturn(Optional.of(serviceTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+                .willReturn(Optional.of(privacyTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+                .willReturn(Optional.of(marketingTerms));
+
+        // when
+        signUpService.signUp(request);
+
+        // then
+        // 약관 동의 이력이 저장되는지 검증
+        then(userTermsAgreementRepository).should().save(any(UserTermsAgreement.class));
     }
     
     

--- a/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
@@ -2,8 +2,9 @@ package kr.co.mapspring.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.CoreMatchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
@@ -40,25 +41,19 @@ class SignUpServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    @InjectMocks
-    private SignUpServiceImpl signUpService;
-    
     @Mock
     private TermsRepository termsRepository;
 
     @Mock
     private UserTermsAgreementRepository userTermsAgreementRepository;
-    
-    private Terms createTerms(TermsType type, boolean required, boolean active) {
-        // 실제 엔티티 생성 방식에 맞춰 다음 단계에서 맞출 예정
-        return null;
-    }
+
+    @InjectMocks
+    private SignUpServiceImpl signUpService;
 
     @Test
     @DisplayName("중복되지 않은 이메일이면 회원가입에 성공한다")
     void signUpSuccess() {
         // given
-        // 회원가입 요청 객체를 만든다.
         SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
                 "홍길동",
                 LocalDate.of(2000, 1, 1),
@@ -72,15 +67,12 @@ class SignUpServiceTest {
                 false
         );
 
-        // 해당 이메일이 아직 존재하지 않는다고 가정한다.
         given(userRepository.existsByEmail("test@naver.com"))
                 .willReturn(false);
 
-        // 비밀번호 암호화 결과를 가정한다.
         given(passwordEncoder.encode("1234"))
                 .willReturn("encodedPassword");
 
-        // 저장 후 반환될 User 객체를 만든다.
         User savedUser = User.builder()
                 .userId(1L)
                 .email("test@naver.com")
@@ -93,8 +85,18 @@ class SignUpServiceTest {
                 .role(UserRole.USER)
                 .build();
 
-        // save 호출 시 위 객체를 반환한다고 가정한다.
-        given(userRepository.save(org.mockito.ArgumentMatchers.any(User.class)))
+        Terms serviceTerms = createTerms(1L, TermsType.SERVICE, true, true);
+        Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
+        Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
+
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+                .willReturn(Optional.of(serviceTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+                .willReturn(Optional.of(privacyTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+                .willReturn(Optional.of(marketingTerms));
+
+        given(userRepository.save(any(User.class)))
                 .willReturn(savedUser);
 
         // when
@@ -106,12 +108,11 @@ class SignUpServiceTest {
         assertThat(response.getEmail()).isEqualTo("test@naver.com");
         assertThat(response.getName()).isEqualTo("홍길동");
     }
-    
+
     @Test
     @DisplayName("이미 존재하는 이메일이면 예외가 발생한다")
     void signUpFailWhenEmailAlreadyExists() {
         // given
-        // 이미 가입된 이메일로 회원가입 요청을 만든다.
         SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
                 "홍길동",
                 LocalDate.of(2000, 1, 1),
@@ -125,23 +126,19 @@ class SignUpServiceTest {
                 false
         );
 
-        // 해당 이메일이 이미 존재한다고 가정한다.
         given(userRepository.existsByEmail("test@naver.com"))
                 .willReturn(true);
 
         // when & then
-        // 회원가입 시 CustomException이 발생하고,
-        // 메시지가 "이미 존재하는 이메일입니다."인지 확인한다.
         assertThatThrownBy(() -> signUpService.signUp(request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("이미 존재하는 이메일입니다.");
     }
-    
+
     @Test
     @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 예외가 발생한다")
     void signUpFailWhenPasswordConfirmDoesNotMatch() {
         // given
-        // 비밀번호와 비밀번호 확인값이 서로 다른 회원가입 요청을 만든다.
         SignUpDto.RequestSignUp request = new SignUpDto.RequestSignUp(
                 "홍길동",
                 LocalDate.of(2000, 1, 1),
@@ -155,18 +152,15 @@ class SignUpServiceTest {
                 false
         );
 
-        // 이메일은 중복되지 않는다고 가정한다.
         given(userRepository.existsByEmail("test@naver.com"))
                 .willReturn(false);
 
         // when & then
-        // 회원가입 시 CustomException이 발생하고,
-        // 메시지가 비밀번호 불일치 메시지인지 확인한다.
         assertThatThrownBy(() -> signUpService.signUp(request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
     }
-    
+
     @Test
     @DisplayName("회원가입 시 비밀번호는 암호화되어 저장된다")
     void signUpPasswordShouldBeEncodedBeforeSave() {
@@ -194,31 +188,40 @@ class SignUpServiceTest {
                 .userId(1L)
                 .email("test@naver.com")
                 .name("홍길동")
-                .birthDate(java.time.LocalDate.of(2000, 1, 1))
+                .birthDate(LocalDate.of(2000, 1, 1))
                 .address("서울시 강남구")
                 .phoneNumber("010-1234-5678")
                 .passwordHash("encodedPassword")
-                .status(kr.co.mapspring.user.enums.UserStatus.ACTIVE)
-                .role(kr.co.mapspring.user.enums.UserRole.USER)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
                 .build();
 
-        given(userRepository.save(org.mockito.ArgumentMatchers.any(User.class)))
+        Terms serviceTerms = createTerms(1L, TermsType.SERVICE, true, true);
+        Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
+        Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
+
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+                .willReturn(Optional.of(serviceTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+                .willReturn(Optional.of(privacyTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+                .willReturn(Optional.of(marketingTerms));
+
+        given(userRepository.save(any(User.class)))
                 .willReturn(savedUser);
 
         // when
         signUpService.signUp(request);
 
         // then
-        // save에 실제로 전달된 User 객체를 캡처한다.
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(userCaptor.capture());
 
         User capturedUser = userCaptor.getValue();
 
-        // 저장 직전 User의 비밀번호가 평문이 아닌 암호화값인지 확인
         assertThat(capturedUser.getPasswordHash()).isEqualTo("encodedPassword");
     }
-    
+
     @Test
     @DisplayName("회원가입 시 기본 상태는 ACTIVE이고 권한은 USER다")
     void signUpShouldSaveDefaultStatusAndRole() {
@@ -246,15 +249,26 @@ class SignUpServiceTest {
                 .userId(1L)
                 .email("test@naver.com")
                 .name("홍길동")
-                .birthDate(java.time.LocalDate.of(2000, 1, 1))
+                .birthDate(LocalDate.of(2000, 1, 1))
                 .address("서울시 강남구")
                 .phoneNumber("010-1234-5678")
                 .passwordHash("encodedPassword")
-                .status(kr.co.mapspring.user.enums.UserStatus.ACTIVE)
-                .role(kr.co.mapspring.user.enums.UserRole.USER)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
                 .build();
 
-        given(userRepository.save(org.mockito.ArgumentMatchers.any(User.class)))
+        Terms serviceTerms = createTerms(1L, TermsType.SERVICE, true, true);
+        Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
+        Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
+
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+                .willReturn(Optional.of(serviceTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+                .willReturn(Optional.of(privacyTerms));
+        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+                .willReturn(Optional.of(marketingTerms));
+
+        given(userRepository.save(any(User.class)))
                 .willReturn(savedUser);
 
         // when
@@ -266,12 +280,10 @@ class SignUpServiceTest {
 
         User capturedUser = userCaptor.getValue();
 
-        assertThat(capturedUser.getStatus())
-                .isEqualTo(kr.co.mapspring.user.enums.UserStatus.ACTIVE);
-        assertThat(capturedUser.getRole())
-                .isEqualTo(kr.co.mapspring.user.enums.UserRole.USER);
+        assertThat(capturedUser.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(capturedUser.getRole()).isEqualTo(UserRole.USER);
     }
-    
+
     @Test
     @DisplayName("서비스 이용약관에 동의하지 않으면 예외가 발생한다")
     void signUpFailWhenServiceTermsNotAgreed() {
@@ -284,9 +296,9 @@ class SignUpServiceTest {
                 "test@naver.com",
                 "1234",
                 "1234",
-                false,   // serviceAgree
-                true,    // privacyAgree
-                false    // marketingAgree
+                false,
+                true,
+                false
         );
 
         // when & then
@@ -294,7 +306,7 @@ class SignUpServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasMessage("서비스 이용약관 동의는 필수입니다.");
     }
-    
+
     @Test
     @DisplayName("개인정보 수집 및 이용에 동의하지 않으면 예외가 발생한다")
     void signUpFailWhenPrivacyTermsNotAgreed() {
@@ -307,9 +319,9 @@ class SignUpServiceTest {
                 "test@naver.com",
                 "1234",
                 "1234",
-                true,    // serviceAgree
-                false,   // privacyAgree
-                false    // marketingAgree
+                true,
+                false,
+                false
         );
 
         // when & then
@@ -317,7 +329,7 @@ class SignUpServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasMessage("개인정보 수집 및 이용 동의는 필수입니다.");
     }
-    
+
     @Test
     @DisplayName("마케팅 정보 수신 동의는 선택이므로 false여도 회원가입에 성공한다")
     void signUpSuccessWhenMarketingAgreeIsFalse() {
@@ -330,9 +342,9 @@ class SignUpServiceTest {
                 "test@naver.com",
                 "1234",
                 "1234",
-                true,    // serviceAgree
-                true,    // privacyAgree
-                false    // marketingAgree
+                true,
+                true,
+                false
         );
 
         given(userRepository.existsByEmail("test@naver.com"))
@@ -353,13 +365,9 @@ class SignUpServiceTest {
                 .role(UserRole.USER)
                 .build();
 
-        given(userRepository.save(any(User.class)))
-                .willReturn(savedUser);
-
-        // 약관 조회 mock
-        Terms serviceTerms = createTerms(TermsType.SERVICE, true, true);
-        Terms privacyTerms = createTerms(TermsType.PRIVACY, true, true);
-        Terms marketingTerms = createTerms(TermsType.MARKETING, false, true);
+        Terms serviceTerms = createTerms(1L, TermsType.SERVICE, true, true);
+        Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
+        Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
 
         given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
                 .willReturn(Optional.of(serviceTerms));
@@ -367,6 +375,9 @@ class SignUpServiceTest {
                 .willReturn(Optional.of(privacyTerms));
         given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
                 .willReturn(Optional.of(marketingTerms));
+
+        given(userRepository.save(any(User.class)))
+                .willReturn(savedUser);
 
         // when
         SignUpDto.ResponseSignUp response = signUpService.signUp(request);
@@ -377,7 +388,7 @@ class SignUpServiceTest {
         assertThat(response.getEmail()).isEqualTo("test@naver.com");
         assertThat(response.getName()).isEqualTo("홍길동");
     }
-    
+
     @Test
     @DisplayName("회원가입 성공 시 사용자 약관 동의 이력이 저장된다")
     void signUpShouldSaveUserTermsAgreements() {
@@ -390,9 +401,9 @@ class SignUpServiceTest {
                 "test@naver.com",
                 "1234",
                 "1234",
-                true,    // serviceAgree
-                true,    // privacyAgree
-                false    // marketingAgree
+                true,
+                true,
+                false
         );
 
         given(userRepository.existsByEmail("test@naver.com"))
@@ -413,12 +424,9 @@ class SignUpServiceTest {
                 .role(UserRole.USER)
                 .build();
 
-        given(userRepository.save(any(User.class)))
-                .willReturn(savedUser);
-
-        Terms serviceTerms = createTerms(TermsType.SERVICE, true, true);
-        Terms privacyTerms = createTerms(TermsType.PRIVACY, true, true);
-        Terms marketingTerms = createTerms(TermsType.MARKETING, false, true);
+        Terms serviceTerms = createTerms(1L, TermsType.SERVICE, true, true);
+        Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
+        Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
 
         given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
                 .willReturn(Optional.of(serviceTerms));
@@ -427,13 +435,26 @@ class SignUpServiceTest {
         given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
                 .willReturn(Optional.of(marketingTerms));
 
+        given(userRepository.save(any(User.class)))
+                .willReturn(savedUser);
+
         // when
         signUpService.signUp(request);
 
         // then
-        // 약관 동의 이력이 저장되는지 검증
         then(userTermsAgreementRepository).should().save(any(UserTermsAgreement.class));
     }
-    
-    
+
+    // 테스트에서 사용할 약관 엔티티 생성 헬퍼
+    private Terms createTerms(Long termId, TermsType type, boolean required, boolean active) {
+        return Terms.builder()
+                .termId(termId)
+                .title(type.name() + " 약관")
+                .content(type.name() + " 약관 내용")
+                .version("v1.0")
+                .type(type)
+                .required(required)
+                .active(active)
+                .build();
+    }
 }

--- a/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/SignUpServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
@@ -89,11 +90,11 @@ class SignUpServiceTest {
         Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
         Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
 
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.SERVICE))
                 .willReturn(Optional.of(serviceTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.PRIVACY))
                 .willReturn(Optional.of(privacyTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.MARKETING))
                 .willReturn(Optional.of(marketingTerms));
 
         given(userRepository.save(any(User.class)))
@@ -200,11 +201,11 @@ class SignUpServiceTest {
         Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
         Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
 
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.SERVICE))
                 .willReturn(Optional.of(serviceTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.PRIVACY))
                 .willReturn(Optional.of(privacyTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.MARKETING))
                 .willReturn(Optional.of(marketingTerms));
 
         given(userRepository.save(any(User.class)))
@@ -261,11 +262,11 @@ class SignUpServiceTest {
         Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
         Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
 
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.SERVICE))
                 .willReturn(Optional.of(serviceTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.PRIVACY))
                 .willReturn(Optional.of(privacyTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.MARKETING))
                 .willReturn(Optional.of(marketingTerms));
 
         given(userRepository.save(any(User.class)))
@@ -369,11 +370,11 @@ class SignUpServiceTest {
         Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
         Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
 
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.SERVICE))
                 .willReturn(Optional.of(serviceTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.PRIVACY))
                 .willReturn(Optional.of(privacyTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.MARKETING))
                 .willReturn(Optional.of(marketingTerms));
 
         given(userRepository.save(any(User.class)))
@@ -428,11 +429,11 @@ class SignUpServiceTest {
         Terms privacyTerms = createTerms(2L, TermsType.PRIVACY, true, true);
         Terms marketingTerms = createTerms(3L, TermsType.MARKETING, false, true);
 
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.SERVICE))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.SERVICE))
                 .willReturn(Optional.of(serviceTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.PRIVACY))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.PRIVACY))
                 .willReturn(Optional.of(privacyTerms));
-        given(termsRepository.findByTypeAndActiveTrue(TermsType.MARKETING))
+        given(termsRepository.findByTermTypeAndActiveTrue(TermsType.MARKETING))
                 .willReturn(Optional.of(marketingTerms));
 
         given(userRepository.save(any(User.class)))
@@ -442,9 +443,13 @@ class SignUpServiceTest {
         signUpService.signUp(request);
 
         // then
-        then(userTermsAgreementRepository).should().save(any(UserTermsAgreement.class));
-    }
+        ArgumentCaptor<UserTermsAgreement> agreementCaptor =
+                ArgumentCaptor.forClass(UserTermsAgreement.class);
 
+        then(userTermsAgreementRepository).should(times(3)).save(agreementCaptor.capture());
+
+        assertThat(agreementCaptor.getAllValues()).hasSize(3);}
+        
     // 테스트에서 사용할 약관 엔티티 생성 헬퍼
     private Terms createTerms(Long termId, TermsType type, boolean required, boolean active) {
         return Terms.builder()


### PR DESCRIPTION
## 작업내용
- 회원가입 2차 약관동의 기능 구현
- 필수 약관 동의 여부 검증 로직 추가
- 사용자 약관 동의 이력 저장 로직 추가
- 회원가입 관련 Swagger 및 Controller docs 정리

## 변경사항
- SignUpDto에 약관 동의 필드 추가
- 회원가입 서비스에 약관 검증 및 약관 동의 이력 저장 로직 반영
- 약관 관련 entity / repository 추가
- 회원가입 약관동의 예외 처리 추가
- 회원가입 약관동의 관련 service / controller 테스트 보완
- Swagger 회원가입 요청/응답 예시 수정


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="692" height="352" alt="image" src="https://github.com/user-attachments/assets/821c8757-8346-4c82-a1b8-5b6fc8bd959b" />
<img width="844" height="722" alt="image" src="https://github.com/user-attachments/assets/13baa658-f8b9-40ec-b8c4-d9e2d9d77ee3" />
서비스 이용약관 false시
<img width="863" height="688" alt="image" src="https://github.com/user-attachments/assets/bce545f7-6230-41cf-b538-88cfda88846d" />
개인정보 수집 및 이용 동의false시
<img width="835" height="658" alt="image" src="https://github.com/user-attachments/assets/211bbab5-c39c-4f63-b868-37f64dcd0c92" />
둘 다 true시



## 참고사항
- 필수 약관은 서비스 이용약관 / 개인정보 수집 및 이용으로 처리
- 마케팅 정보 수신 동의는 선택값으로 처리
- 활성 약관 데이터가 필요하여 DB 더미 데이터 기준으로 Swagger 확인
- Swagger 테스트시 전화번호와 email 값은 중복이 불가능하기 떄문에 +1씩 늘려가면서 확인 가능 
-  #36 이슈도 같이 해결

**약관동의 더미데이터 값** 

```
INSERT INTO terms (
    title,
    content,
    version,
    term_type,
    is_required,
    is_active,
    created_at,
    updated_at
) VALUES
('서비스 이용약관', '서비스 이용약관 내용입니다.', 'v1.0', 'SERVICE', true, true, NOW(), NOW()),
('개인정보 수집 및 이용 동의', '개인정보 수집 및 이용 내용입니다.', 'v1.0', 'PRIVACY', true, true, NOW(), NOW()),
('마케팅 정보 수신 동의', '마케팅 수신 동의 내용입니다.', 'v1.0', 'MARKETING', false, true, NOW(), NOW());
```
