### PR TITLE
feat(ranking): 랭킹 조회 기능 구현 (전체랭킹/내랭킹)

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
 	//User 약관동의용
 	SERVICE_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "서비스 이용약관 동의는 필수입니다."),
 	PRIVACY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "개인정보 수집 및 이용 동의는 필수입니다."),
-	TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "활성 약관 정보를 찾을 수 없습니다.");
+	TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "활성 약관 정보를 찾을 수 없습니다."),
 
     // Favorite Place
     FAVORITE_PLACE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기한 장소입니다."),

--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -34,7 +34,10 @@ public enum ErrorCode {
     GOAL_MASTER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 학습 목표입니다."),
     GOAL_ALREADY_SELECTED(HttpStatus.CONFLICT, "이미 선택한 학습 목표입니다."),
     GOAL_SELECTION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "학습 목표는 최대 3개까지만 선택할 수 있습니다."),
-    USER_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 목표입니다.");
+    USER_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 목표입니다."),
+
+    // Ranking
+    RANKING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 랭킹이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/kr/co/mapspring/global/exception/ranking/RankingNotFoundException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ranking/RankingNotFoundException.java
@@ -1,0 +1,9 @@
+package kr.co.mapspring.global.exception.ranking;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class RankingNotFoundException extends CustomException {
+
+    public RankingNotFoundException() { super(ErrorCode.RANKING_NOT_FOUND); }
+}

--- a/src/main/java/kr/co/mapspring/ranking/controller/RankingController.java
+++ b/src/main/java/kr/co/mapspring/ranking/controller/RankingController.java
@@ -1,0 +1,36 @@
+package kr.co.mapspring.ranking.controller;
+
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.ranking.controller.docs.RankingControllerDocs;
+import kr.co.mapspring.ranking.dto.RankingDto;
+import kr.co.mapspring.ranking.service.RankingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rankings")
+public class RankingController implements RankingControllerDocs {
+
+    private final RankingService rankingService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponseDTO<List<RankingDto.ResponseRanking>>> getRankings() {
+        List<RankingDto.ResponseRanking> result = rankingService.getRankings();
+        return ResponseEntity.ok(ApiResponseDTO.success("전체 랭킹 조회 성공", result));
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponseDTO<RankingDto.ResponseRanking>> getMyRanking(@RequestParam("userId") Long userId) {
+        RankingDto.ResponseRanking result = rankingService.getMyRanking(userId);
+        return ResponseEntity.ok(ApiResponseDTO.success("내 랭킹 조회 성공", result));
+    }
+}

--- a/src/main/java/kr/co/mapspring/ranking/controller/docs/RankingControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/ranking/controller/docs/RankingControllerDocs.java
@@ -1,14 +1,16 @@
 package kr.co.mapspring.ranking.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.mapspring.global.dto.ApiResponseDTO;
 import kr.co.mapspring.ranking.dto.RankingDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -19,36 +21,88 @@ public interface RankingControllerDocs {
             summary = "전체 랭킹 조회",
             description = "사용자별 총 점수를 기준으로 전체 랭킹을 조회합니다."
     )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "전체 랭킹 조회 성공",
-                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
-            ),
-            @ApiResponse(responseCode = "500",
-                    description = "서버 오류",
-                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "전체 랭킹 조회 성공"),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 500,
+                                              "message": "서버 내부 오류가 발생했습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
             )
     })
     ResponseEntity<ApiResponseDTO<List<RankingDto.ResponseRanking>>> getRankings();
-
 
     @Operation(
             summary = "내 랭킹 조회",
             description = "userId를 기준으로 자신의 랭킹을 조회합니다."
     )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "내 랭킹 조회 성공",
-                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
-            ),
-            @ApiResponse(responseCode = "400",
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 랭킹 조회 성공"),
+            @ApiResponse(
+                    responseCode = "400",
                     description = "잘못된 요청",
-                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "잘못된 요청입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
             ),
-            @ApiResponse(responseCode = "500",
-                    description = "서버 오류",
-                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 404,
+                                              "message": "사용자를 찾을 수 없습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 500,
+                                              "message": "서버 내부 오류가 발생했습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
             )
     })
-    ResponseEntity<ApiResponseDTO<RankingDto.ResponseRanking>> getMyRanking(Long userId);
+    ResponseEntity<ApiResponseDTO<RankingDto.ResponseRanking>> getMyRanking(
+            @Parameter(description = "사용자 ID", example = "1", required = true)
+            @RequestParam("userId") Long userId
+    );
 }

--- a/src/main/java/kr/co/mapspring/ranking/controller/docs/RankingControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/ranking/controller/docs/RankingControllerDocs.java
@@ -1,0 +1,54 @@
+package kr.co.mapspring.ranking.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.ranking.dto.RankingDto;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Ranking", description = "랭킹 조회 API")
+public interface RankingControllerDocs {
+
+    @Operation(
+            summary = "전체 랭킹 조회",
+            description = "사용자별 총 점수를 기준으로 전체 랭킹을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "전체 랭킹 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            ),
+            @ApiResponse(responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            )
+    })
+    ResponseEntity<ApiResponseDTO<List<RankingDto.ResponseRanking>>> getRankings();
+
+
+    @Operation(
+            summary = "내 랭킹 조회",
+            description = "userId를 기준으로 자신의 랭킹을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "내 랭킹 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            ),
+            @ApiResponse(responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            ),
+            @ApiResponse(responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))
+            )
+    })
+    ResponseEntity<ApiResponseDTO<RankingDto.ResponseRanking>> getMyRanking(Long userId);
+}

--- a/src/main/java/kr/co/mapspring/ranking/dto/RankingDto.java
+++ b/src/main/java/kr/co/mapspring/ranking/dto/RankingDto.java
@@ -19,13 +19,14 @@ public class RankingDto {
             this.userId = userId;
             this.totalScore = totalScore;
         }
+
+        public static ResponseRanking from(int rank, Long userId, Long totalScore) {
+            return ResponseRanking.builder()
+                    .rank(rank)
+                    .userId(userId)
+                    .totalScore(totalScore)
+                    .build();
+        }
     }
 
-    public static ResponseRanking from(int rank, Long userId, Long totalScore) {
-        return ResponseRanking.builder()
-                .rank(rank)
-                .userId(userId)
-                .totalScore(totalScore)
-                .build();
-    }
 }

--- a/src/main/java/kr/co/mapspring/ranking/dto/RankingDto.java
+++ b/src/main/java/kr/co/mapspring/ranking/dto/RankingDto.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.ranking.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,9 +9,16 @@ public class RankingDto {
 
     @Getter
     @NoArgsConstructor
+    @Schema(description = "랭킹 조회 응답 DTO")
     public static class ResponseRanking {
+
+        @Schema(description = "순위", example = "1")
         private int rank;
+
+        @Schema(description = "사용자 ID", example = "3")
         private Long userId;
+
+        @Schema(description = "총 점수", example = "950")
         private Long totalScore;
 
         @Builder

--- a/src/main/java/kr/co/mapspring/ranking/dto/RankingDto.java
+++ b/src/main/java/kr/co/mapspring/ranking/dto/RankingDto.java
@@ -1,0 +1,31 @@
+package kr.co.mapspring.ranking.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RankingDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class ResponseRanking {
+        private int rank;
+        private Long userId;
+        private Long totalScore;
+
+        @Builder
+        public ResponseRanking(int rank, Long userId, Long totalScore) {
+            this.rank = rank;
+            this.userId = userId;
+            this.totalScore = totalScore;
+        }
+    }
+
+    public static ResponseRanking from(int rank, Long userId, Long totalScore) {
+        return ResponseRanking.builder()
+                .rank(rank)
+                .userId(userId)
+                .totalScore(totalScore)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
+++ b/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
@@ -1,0 +1,17 @@
+package kr.co.mapspring.ranking.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface RankingRepository extends JpaRepository<StudyLog, Long> {
+
+    @Query("""
+           SELECT s.userId, SUM(s.score)
+           FROM StudyLog s
+           GROUP BY s.userId
+           ORDER BY SUM(s.score) DESC    
+           """)
+    List<Object[]> findRanking();
+}

--- a/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
+++ b/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
@@ -1,17 +1,18 @@
 package kr.co.mapspring.ranking.repository;
 
+import kr.co.mapspring.learning.entity.StudyScore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface RankingRepository extends JpaRepository<StudyLog, Long> {
+public interface RankingRepository extends JpaRepository<StudyScore, Long> {
 
     @Query("""
-           SELECT s.userId, SUM(s.score)
-           FROM StudyLog s
-           GROUP BY s.userId
-           ORDER BY SUM(s.score) DESC    
+           SELECT ss.studyLog.userId, SUM(ss.totalScore)
+           FROM StudyScore ss
+           GROUP BY ss.studyLog.userId
+           ORDER BY SUM(ss.totalScore) DESC    
            """)
     List<Object[]> findRanking();
 }

--- a/src/main/java/kr/co/mapspring/ranking/service/RankingService.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/RankingService.java
@@ -1,0 +1,36 @@
+package kr.co.mapspring.ranking.service;
+
+public interface RankingService {
+
+    /**
+     * 전체 랭킹 조회
+     *
+     * [설명]
+     * - study_log 테이블을 기반으로 사용자별 score 합계를 계산하여
+     *   점수가 높은 순으로 랭킹을 반환한다.
+     *
+     * [동작]
+     * - userId 기준으로 score SUM 집계
+     * - 점수 내림차순 정렬
+     * - 순위(rank)는 Service에서 생성
+     *
+     * @return 사용자별 랭킹 리스트 (순위, userId, 총 점수 포함)
+     */
+    List<RankingDto.ResponseRanking> getRankings();
+
+    /**
+     *
+     * 내 랭킹 조회
+     *
+     * [설명]
+     * - 전체 랭킹 목록에서 특정 userId에 해당하는 사용자의 순위를 조회한다.
+     *
+     * [동장]
+     * - 전체 랭킹 조회 후
+     * - userId와 일치하는 데이터 필터링
+     *
+     * @param userId 랭킹을 조회할 사용자 ID
+     * @return 해당 사용자의 랭킹 정보 (순위, userId, 총 점수)
+     */
+    RankingDto.ResponseRanking getMyRanking(Long userId);
+}

--- a/src/main/java/kr/co/mapspring/ranking/service/RankingService.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/RankingService.java
@@ -1,5 +1,9 @@
 package kr.co.mapspring.ranking.service;
 
+import kr.co.mapspring.ranking.dto.RankingDto;
+
+import java.util.List;
+
 public interface RankingService {
 
     /**

--- a/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
@@ -1,11 +1,11 @@
 package kr.co.mapspring.ranking.service.impl;
 
-import jakarta.transaction.Transactional;
 import kr.co.mapspring.ranking.dto.RankingDto;
 import kr.co.mapspring.ranking.repository.RankingRepository;
 import kr.co.mapspring.ranking.service.RankingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.IntStream;

--- a/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
@@ -1,0 +1,46 @@
+package kr.co.mapspring.ranking.service.impl;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RankingServiceImpl implements RankingService {
+
+    private final RankingRepository rankingRepository;
+
+    @Override
+    public List<RankingDto.ResponseRanking> getRankings() {
+
+        List<Object[]> rankingResult = rankingRepository.findRanking();
+
+        return IntStream.range(0, rankingResult.size())
+                .mapToObj(index -> {
+                    Object[] row = rankingResult.get(index);
+
+                    Long userId = (Long) row[0];
+                    Long totalScore = (Long) row[1];
+
+                    return RankingDto.ResponseRanking.from(
+                            index + 1,
+                            userId,
+                            totalScore
+                    );
+                })
+                .toList();
+    }
+
+    @Override
+    public RankingDto.ResponseRanking getMyRanking(Long userId) {
+
+        return getRankings().stream()
+                .filter(ranking -> ranking.getUserId().equals(userId))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
@@ -1,5 +1,8 @@
 package kr.co.mapspring.ranking.service.impl;
 
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+import kr.co.mapspring.global.exception.ranking.RankingNotFoundException;
 import kr.co.mapspring.ranking.dto.RankingDto;
 import kr.co.mapspring.ranking.repository.RankingRepository;
 import kr.co.mapspring.ranking.service.RankingService;
@@ -44,6 +47,6 @@ public class RankingServiceImpl implements RankingService {
         return getRankings().stream()
                 .filter(ranking -> ranking.getUserId().equals(userId))
                 .findFirst()
-                .orElse(null);
+                .orElseThrow(RankingNotFoundException::new);
     }
 }

--- a/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
@@ -2,6 +2,7 @@ package kr.co.mapspring.ranking.service.impl;
 
 import jakarta.transaction.Transactional;
 import kr.co.mapspring.ranking.dto.RankingDto;
+import kr.co.mapspring.ranking.repository.RankingRepository;
 import kr.co.mapspring.ranking.service.RankingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
@@ -1,6 +1,8 @@
 package kr.co.mapspring.ranking.service.impl;
 
 import jakarta.transaction.Transactional;
+import kr.co.mapspring.ranking.dto.RankingDto;
+import kr.co.mapspring.ranking.service.RankingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/test/java/kr/co/mapspring/ranking/service/RankingServiceTest.java
+++ b/src/test/java/kr/co/mapspring/ranking/service/RankingServiceTest.java
@@ -1,0 +1,81 @@
+package kr.co.mapspring.ranking.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class RankingServiceTest {
+
+    @Mock
+    private RankingRepository rankingRepository;
+
+    @InjectMocks
+    private RankingServiceImpl rankingService;
+
+    @Test
+    @DisplayName("전체 랭킹을 점수 내림차순으로 조회한다")
+    void 전체_랭킹을_점수_내림차순으로_조회한다() {
+
+        List<Object[]> rankingResult = List.of(
+                new Object[]{1L, 300L},
+                new Object[]{2L, 200L},
+                new Object[]{3L, 100L}
+        );
+
+        given(rankingRepository.findRanking())
+                .willReturn(rankingResult);
+
+        List<RankingDto.ResponseRanking> result = rankingService.getRanings();
+
+        verify(rankingRepository).findRanking();
+
+        assertEquals(3, result.size());
+
+        assertEquals(1, result.get(0).getRank());
+        assertEquals(1L, result.get(0).getUserId());
+        assertEquals(300L, result.get(0).getTotalScore());
+
+        assertEquals(2, result.get(1).getRank());
+        assertEquals(2L, result.get(1).getUserId());
+        assertEquals(200L, result.get(1).getTotalScore());
+
+        assertEquals(3, result.get(2).getRank());
+        assertEquals(3L, result.get(2).getUserId());
+        assertEquals(100L, result.get(2).getTotalScore());
+    }
+
+    @Test
+    @DisplayName("내 랭킹을 정상적으로 조회한다")
+    void 내_랭킹을_정상적으로_조회한다() {
+
+        Long userId = 2L;
+
+        List<Object[]> rankingResult = List.ok(
+                new Object[]{1L, 300L},
+                new Object[]{2L, 200L},
+                new Object[]{3L, 100L}
+        );
+
+                given(rankingRepository.findRanking())
+                        .willReturn(rankingResult);
+
+        RankingDto.ResponseRanking result = rankingService.getMyRanking(userId);
+
+        verify(rankingRepository).findRanking();
+
+        assertEquals(2, result.getRank());
+        assertEquals(userId, result.getUserId());
+        assertEquals(200L, result.getTotalScore());
+    }
+
+}

--- a/src/test/java/kr/co/mapspring/ranking/service/RankingServiceTest.java
+++ b/src/test/java/kr/co/mapspring/ranking/service/RankingServiceTest.java
@@ -1,5 +1,8 @@
 package kr.co.mapspring.ranking.service;
 
+import kr.co.mapspring.ranking.dto.RankingDto;
+import kr.co.mapspring.ranking.repository.RankingRepository;
+import kr.co.mapspring.ranking.service.impl.RankingServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +38,7 @@ public class RankingServiceTest {
         given(rankingRepository.findRanking())
                 .willReturn(rankingResult);
 
-        List<RankingDto.ResponseRanking> result = rankingService.getRanings();
+        List<RankingDto.ResponseRanking> result = rankingService.getRankings();
 
         verify(rankingRepository).findRanking();
 
@@ -60,7 +63,7 @@ public class RankingServiceTest {
 
         Long userId = 2L;
 
-        List<Object[]> rankingResult = List.ok(
+        List<Object[]> rankingResult = List.of(
                 new Object[]{1L, 300L},
                 new Object[]{2L, 200L},
                 new Object[]{3L, 100L}


### PR DESCRIPTION
## 작업내용
- 랭킹 조회 API 구현
- 전체 랭킹 조회 기능 구현
- 내 랭킹 조회 기능 구현

## 변경사항
- RankingController / RankingControllerDocs 추가
- RankingService / RankingServiceImpl 추가
- RankingRepository 추가 (JPQL 기반 집계 쿼리)
- RankingDto 추가
- ErrorCode에 RANKING_NOT_FOUND 추가
- CustomException 기반 예외 처리 적용


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [v] 단위 테스트 완료
- [v] Swagger 테스트 완료
<img width="355" height="298" alt="image" src="https://github.com/user-attachments/assets/38ddb31d-96a9-476e-ab53-7c67b0570b32" />

## 참고사항
- study_score의 totalScore를 기준으로 사용자별 랭킹 계산
- 랭킹 데이터는 별도 테이블 없이 집계 쿼리로 처리
- 랭킹 기능에서 study_log 테이블을 사용하기 위해 feature/learning 브랜치를 merge했습니다.
- 따라서 본 PR에는 learning 관련 커밋이 일부 포함되어 있습니다.
- test(ranking): ~~ 부터 확인 부탁드립니다 !!

- 랭킹 기능 테스트를 위해 로컬 환경에서 아래 더미 데이터를 사용하였습니다.
- 해당 데이터는 API 동작 확인을 위한 테스트 용도이며, 실제 서비스 코드에는 포함되지 않습니다.

```sql
-- study_log 더미 데이터
INSERT INTO study_log (user_id, session_id, study_type, earned_exp)
VALUES (1, 1, 'PLACE', 100),
       (2, 1, 'PLACE', 100),
       (3, 1, 'PLACE', 100);

-- study_score 더미 데이터
INSERT INTO study_score (study_log_id, total_score)
VALUES (1, 300),
       (2, 200),
       (3, 100);

