### PR TITLE
fix: StudyScoreRepository userId 경로 오류 수정

### DIFF
--- a/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
+++ b/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
@@ -9,9 +9,9 @@ import java.util.List;
 public interface RankingRepository extends JpaRepository<StudyScore, Long> {
 
     @Query("""
-           SELECT ss.studyLog.userId, SUM(ss.totalScore)
+           SELECT ss.studyLog.user.userId, SUM(ss.totalScore)
            FROM StudyScore ss
-           GROUP BY ss.studyLog.userId
+           GROUP BY ss.studyLog.user.userId
            ORDER BY SUM(ss.totalScore) DESC    
            """)
     List<Object[]> findRanking();


### PR DESCRIPTION
## 작업내용
- StudyScoreRepository 쿼리 및 메서드 경로 수정
- StudyLog의 user 필드가 User 객체인데 userId로 직접 접근하던 문제 해결
- fixes: #57 

## 변경사항
- ss.studyLog.userId → ss.studyLog.user.userId 로 수정
- findAllByStudyLog_UserId → findAllByStudyLog_User_UserId 로 수정

## 문제 원인
- StudyLog에 Long userId가 아닌 User user로 매핑되어 있음
- JPA가 경로를 해석할 때 user.id를 찾다가 실패하면서 오류 발생

## 결과
- ApplicationContext 정상 실행
- 랭킹 조회 쿼리 정상 동작

## 참고사항
- 엔티티 구조 변경 시 Repository 메서드 네이밍도 반드시 함께 수정 필요

