### PR TITLE
feat(JWT): JWT + Redis Refresh Token 2차 구현 / Refresh Token Rotation 재발급 API

### DIFF
--- a/src/main/java/kr/co/mapspring/global/config/OpenApiConfig.java
+++ b/src/main/java/kr/co/mapspring/global/config/OpenApiConfig.java
@@ -1,0 +1,40 @@
+package kr.co.mapspring.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class OpenApiConfig {
+
+    // Swagger UI에서 사용할 JWT 인증 스키마 이름
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                // Swagger 전체 API에 bearerAuth 보안 스키마를 적용한다.
+                // 현재 SecurityConfig는 B안(permitAll)이므로 실제 API 접근은 막지 않는다.
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+
+                // Swagger UI에 Authorize 버튼을 만들기 위한 보안 스키마 설정
+                .components(new Components()
+                        .addSecuritySchemes(
+                                SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        // HTTP 인증 방식 사용
+                                        .type(SecurityScheme.Type.HTTP)
+
+                                        // Bearer Token 방식 사용
+                                        .scheme("bearer")
+
+                                        // JWT 형식의 Bearer Token임을 표시
+                                        .bearerFormat("JWT")
+                        )
+                );
+    }
+}

--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
 	SERVICE_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "서비스 이용약관 동의는 필수입니다."),
 	PRIVACY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "개인정보 수집 및 이용 동의는 필수입니다."),
 	TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "활성 약관 정보를 찾을 수 없습니다."),
+	
+	// JWT 토큰용
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
 
     // Favorite Place
     FAVORITE_PLACE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기한 장소입니다."),

--- a/src/main/java/kr/co/mapspring/global/exception/user/InactiveUserException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/user/InactiveUserException.java
@@ -1,8 +1,11 @@
 package kr.co.mapspring.global.exception.user;
 
-public class InactiveUserException extends RuntimeException {
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class InactiveUserException extends CustomException {
 
     public InactiveUserException() {
-        super("비활성 사용자입니다.");
+        super(ErrorCode.INACTIVE_USER);
     }
 }

--- a/src/main/java/kr/co/mapspring/global/exception/user/InvalidRefreshTokenException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/user/InvalidRefreshTokenException.java
@@ -3,8 +3,10 @@ package kr.co.mapspring.global.exception.user;
 import kr.co.mapspring.global.exception.CustomException;
 import kr.co.mapspring.global.exception.ErrorCode;
 
-public class UserNotFoundException extends CustomException {
-    public UserNotFoundException() {
-        super(ErrorCode.USER_NOT_FOUND);
+public class InvalidRefreshTokenException extends CustomException {
+	
+	public InvalidRefreshTokenException() {
+        super(ErrorCode.INVALID_REFRESH_TOKEN);
     }
+
 }

--- a/src/main/java/kr/co/mapspring/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/co/mapspring/global/jwt/JwtTokenProvider.java
@@ -86,6 +86,22 @@ public class JwtTokenProvider {
             return false;
         }
     }
+    
+ // Refresh Token 유효성 검증
+    public boolean validateRefreshToken(String token) {
+        try {
+            Claims claims = getClaims(token);
+
+            // tokenType이 REFRESH인 토큰만 Refresh Token으로 인정한다.
+            return "REFRESH".equals(claims.get("tokenType", String.class));
+
+        } catch (JwtException | IllegalArgumentException e) {
+            // 만료, 서명 오류, 토큰 형식 오류 등은 false 처리한다.
+            return false;
+        }
+    }
+    
+    
 
     // JWT subject에서 userId를 꺼낸다.
     public Long getUserId(String token) {

--- a/src/main/java/kr/co/mapspring/global/jwt/RefreshTokenService.java
+++ b/src/main/java/kr/co/mapspring/global/jwt/RefreshTokenService.java
@@ -34,4 +34,20 @@ public class RefreshTokenService {
         stringRedisTemplate.opsForValue()
                 .set(key, refreshToken, Duration.ofMillis(refreshTokenExpiration));
     }
+    
+ // Redis에 저장된 Refresh Token을 조회한다.
+    public String getRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+
+        return stringRedisTemplate.opsForValue().get(key);
+    }
+
+    // 요청으로 들어온 Refresh Token과 Redis에 저장된 Refresh Token이 같은지 확인한다.
+    public boolean isRefreshTokenMatched(Long userId, String refreshToken) {
+        String savedRefreshToken = getRefreshToken(userId);
+
+        return refreshToken != null && refreshToken.equals(savedRefreshToken);
+    }
+    
+    
 }

--- a/src/main/java/kr/co/mapspring/user/controller/AuthController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/AuthController.java
@@ -1,13 +1,20 @@
 package kr.co.mapspring.user.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
 import kr.co.mapspring.global.dto.ApiResponseDTO;
 import kr.co.mapspring.user.controller.docs.AuthControllerDocs;
 import kr.co.mapspring.user.dto.LoginDto;
 import kr.co.mapspring.user.dto.SignUpDto;
+import kr.co.mapspring.user.dto.TokenDto;
 import kr.co.mapspring.user.service.LoginService;
 import kr.co.mapspring.user.service.SignUpService;
+import kr.co.mapspring.user.service.TokenService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -19,6 +26,9 @@ public class AuthController implements AuthControllerDocs {
 
     // 회원가입 서비스
     private final SignUpService signUpService;
+    
+    // 토큰 서비스
+    private final TokenService tokenService;
 
     @Override
     @PostMapping("/login")
@@ -43,4 +53,18 @@ public class AuthController implements AuthControllerDocs {
         // 공통 성공 응답 반환
         return ApiResponseDTO.success("회원가입 성공", response);
     }
+    
+    @Override
+    @PostMapping("/tokens")
+    public ApiResponseDTO<TokenDto.ResponseReissue> reissueToken(
+            @Valid @RequestBody TokenDto.RequestReissue request
+    ) {
+        // Refresh Token 기반 토큰 재발급 서비스 호출
+        TokenDto.ResponseReissue response = tokenService.reissue(request);
+
+        // 공통 성공 응답 반환
+        return ApiResponseDTO.success("토큰 재발급 성공", response);
+    }
+    
+    
 }

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
@@ -11,22 +11,48 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.mapspring.global.dto.ApiResponseDTO;
 import kr.co.mapspring.user.dto.LoginDto;
 import kr.co.mapspring.user.dto.SignUpDto;
+import kr.co.mapspring.user.dto.TokenDto;
 
 @Tag(name = "Auth", description = "인증 관련 API")
 public interface AuthControllerDocs {
 
     @Operation(
             summary = "로그인",
-            description = "이메일과 비밀번호를 입력받아 로그인 처리하고 사용자 정보를 반환합니다."
+            description = "이메일과 비밀번호를 입력받아 로그인 처리하고 사용자 정보 및 토큰 정보를 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "로그인 성공",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "로그인 성공",
+                                              "data": {
+                                                "userId": 1,
+                                                "email": "test@naver.com",
+                                                "name": "홍길동",
+                                                "role": "USER",
+                                                "accessToken": "<ACCESS_TOKEN>",
+                                                "refreshToken": "<REFRESH_TOKEN>"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(
                     responseCode = "404",
                     description = "존재하지 않는 이메일",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
+                                    name = "존재하지 않는 이메일",
                                     value = """
                                             {
                                               "success": false,
@@ -44,6 +70,7 @@ public interface AuthControllerDocs {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
+                                    name = "비밀번호 불일치",
                                     value = """
                                             {
                                               "success": false,
@@ -61,6 +88,7 @@ public interface AuthControllerDocs {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
+                                    name = "비활성 사용자",
                                     value = """
                                             {
                                               "success": false,
@@ -98,36 +126,23 @@ public interface AuthControllerDocs {
             description = "이름, 생년월일, 주소, 전화번호, 이메일, 비밀번호 및 약관 동의 여부를 입력받아 회원가입을 처리합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
             @ApiResponse(
-                    responseCode = "409",
-                    description = "이미 존재하는 이메일",
+                    responseCode = "200",
+                    description = "회원가입 성공",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
+                                    name = "회원가입 성공",
                                     value = """
                                             {
-                                              "success": false,
-                                              "status": 409,
-                                              "message": "이미 존재하는 이메일입니다.",
-                                              "data": null
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "409",
-                    description = "이미 존재하는 전화번호",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "success": false,
-                                              "status": 409,
-                                              "message": "이미 존재하는 전화번호입니다.",
-                                              "data": null
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "회원가입 성공",
+                                              "data": {
+                                                "userId": 1,
+                                                "email": "test@naver.com",
+                                                "name": "홍길동"
+                                              }
                                             }
                                             """
                             )
@@ -135,70 +150,59 @@ public interface AuthControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "비밀번호 확인 불일치",
+                    description = "회원가입 요청값 오류",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "success": false,
-                                              "status": 400,
-                                              "message": "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
-                                              "data": null
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "입력값 검증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "success": false,
-                                              "status": 400,
-                                              "message": "입력값 검증 실패",
-                                              "data": null
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "서비스 이용약관 미동의",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "success": false,
-                                              "status": 400,
-                                              "message": "서비스 이용약관 동의는 필수입니다.",
-                                              "data": null
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "개인정보 수집 및 이용 미동의",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "success": false,
-                                              "status": 400,
-                                              "message": "개인정보 수집 및 이용 동의는 필수입니다.",
-                                              "data": null
-                                            }
-                                            """
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "비밀번호 확인 불일치",
+                                            summary = "password와 passwordConfirm이 일치하지 않는 경우",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "status": 400,
+                                                      "message": "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "입력값 검증 실패",
+                                            summary = "생년월일 형식 오류 등 요청값 검증에 실패한 경우",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "status": 400,
+                                                      "message": "입력값 검증 실패",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "서비스 이용약관 미동의",
+                                            summary = "serviceAgree가 false인 경우",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "status": 400,
+                                                      "message": "서비스 이용약관 동의는 필수입니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "개인정보 수집 및 이용 미동의",
+                                            summary = "privacyAgree가 false인 경우",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "status": 400,
+                                                      "message": "개인정보 수집 및 이용 동의는 필수입니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @ApiResponse(
@@ -207,6 +211,7 @@ public interface AuthControllerDocs {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
+                                    name = "활성 약관 정보 없음",
                                     value = """
                                             {
                                               "success": false,
@@ -216,6 +221,39 @@ public interface AuthControllerDocs {
                                             }
                                             """
                             )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "회원가입 중복 리소스",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "이미 존재하는 이메일",
+                                            summary = "email이 이미 존재하는 경우",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "status": 409,
+                                                      "message": "이미 존재하는 이메일입니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "이미 존재하는 전화번호",
+                                            summary = "phoneNumber가 이미 존재하는 경우",
+                                            value = """
+                                                    {
+                                                      "success": false,
+                                                      "status": 409,
+                                                      "message": "이미 존재하는 전화번호입니다.",
+                                                      "data": null
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             )
     })
@@ -245,5 +283,87 @@ public interface AuthControllerDocs {
                     )
             )
             SignUpDto.RequestSignUp request
+    );
+
+    @Operation(
+            summary = "Access Token 및 Refresh Token 재발급",
+            description = "Refresh Token을 검증한 뒤 새로운 Access Token과 Refresh Token을 발급합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "토큰 재발급 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "토큰 재발급 성공",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "토큰 재발급 성공",
+                                              "data": {
+                                                "accessToken": "<NEW_ACCESS_TOKEN>",
+                                                "refreshToken": "<NEW_REFRESH_TOKEN>"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "유효하지 않은 Refresh Token",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "유효하지 않은 Refresh Token",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 401,
+                                              "message": "Refresh Token이 유효하지 않습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "비활성 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "비활성 사용자",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 403,
+                                              "message": "비활성 사용자입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponseDTO<TokenDto.ResponseReissue> reissueToken(
+            @RequestBody(
+                    description = "토큰 재발급 요청 정보",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = TokenDto.RequestReissue.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "refreshToken": "<REFRESH_TOKEN>"
+                                            }
+                                            """
+                            )
+                    )
+            )
+            TokenDto.RequestReissue request
     );
 }

--- a/src/main/java/kr/co/mapspring/user/dto/TokenDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/TokenDto.java
@@ -1,0 +1,5 @@
+package kr.co.mapspring.user.dto;
+
+public class TokenDto {
+
+}

--- a/src/main/java/kr/co/mapspring/user/dto/TokenDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/TokenDto.java
@@ -1,5 +1,43 @@
 package kr.co.mapspring.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class TokenDto {
 
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "토큰 재발급 요청 DTO")
+    public static class RequestReissue {
+
+        @NotBlank(message = "Refresh Token은 필수 입력 값입니다.")
+        @Schema(description = "JWT Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        private String refreshToken;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "토큰 재발급 응답 DTO")
+    public static class ResponseReissue {
+
+        @Schema(description = "새로 발급된 JWT Access Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        private String accessToken;
+
+        @Schema(description = "새로 발급된 JWT Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        private String refreshToken;
+
+        public static ResponseReissue of(String accessToken, String refreshToken) {
+            return ResponseReissue.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/kr/co/mapspring/user/service/TokenService.java
+++ b/src/main/java/kr/co/mapspring/user/service/TokenService.java
@@ -1,5 +1,9 @@
 package kr.co.mapspring.user.service;
 
-public class TokenService {
+import kr.co.mapspring.user.dto.TokenDto;
 
+public interface TokenService {
+
+    // Refresh Token을 검증한 뒤 Access Token과 Refresh Token을 재발급한다.
+    TokenDto.ResponseReissue reissue(TokenDto.RequestReissue request);
 }

--- a/src/main/java/kr/co/mapspring/user/service/TokenService.java
+++ b/src/main/java/kr/co/mapspring/user/service/TokenService.java
@@ -1,0 +1,5 @@
+package kr.co.mapspring.user.service;
+
+public class TokenService {
+
+}

--- a/src/main/java/kr/co/mapspring/user/service/impl/TokenServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/TokenServiceImpl.java
@@ -1,0 +1,5 @@
+package kr.co.mapspring.user.service.impl;
+
+public class TokenServiceImpl {
+
+}

--- a/src/main/java/kr/co/mapspring/user/service/impl/TokenServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/TokenServiceImpl.java
@@ -1,17 +1,22 @@
 package kr.co.mapspring.user.service.impl;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import kr.co.mapspring.global.exception.CustomException;
-import kr.co.mapspring.global.exception.ErrorCode;
+import kr.co.mapspring.global.exception.user.InactiveUserException;
+import kr.co.mapspring.global.exception.user.InvalidRefreshTokenException;
+import kr.co.mapspring.global.exception.user.UserNotFoundException;
 import kr.co.mapspring.global.jwt.JwtTokenProvider;
 import kr.co.mapspring.global.jwt.RefreshTokenService;
 import kr.co.mapspring.user.dto.TokenDto;
 import kr.co.mapspring.user.entity.User;
 import kr.co.mapspring.user.repository.UserRepository;
 import kr.co.mapspring.user.service.TokenService;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TokenServiceImpl implements TokenService {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -20,35 +25,26 @@ public class TokenServiceImpl implements TokenService {
 
     private final UserRepository userRepository;
 
-    public TokenServiceImpl(
-            JwtTokenProvider jwtTokenProvider,
-            RefreshTokenService refreshTokenService,
-            UserRepository userRepository
-    ) {
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.refreshTokenService = refreshTokenService;
-        this.userRepository = userRepository;
-    }
-
     @Override
+    @Transactional
     public TokenDto.ResponseReissue reissue(TokenDto.RequestReissue request) {
         String refreshToken = request.getRefreshToken();
 
         if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
-            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+            throw new InvalidRefreshTokenException();
         }
 
         Long userId = jwtTokenProvider.getUserId(refreshToken);
 
         if (!refreshTokenService.isRefreshTokenMatched(userId, refreshToken)) {
-            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+            throw new InvalidRefreshTokenException();
         }
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(UserNotFoundException::new);
 
         if (!user.isActive()) {
-            throw new CustomException(ErrorCode.INACTIVE_USER);
+            throw new InactiveUserException();
         }
 
         String newAccessToken = jwtTokenProvider.createAccessToken(user);

--- a/src/main/java/kr/co/mapspring/user/service/impl/TokenServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/TokenServiceImpl.java
@@ -1,5 +1,62 @@
 package kr.co.mapspring.user.service.impl;
 
-public class TokenServiceImpl {
+import org.springframework.stereotype.Service;
 
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+import kr.co.mapspring.global.jwt.JwtTokenProvider;
+import kr.co.mapspring.global.jwt.RefreshTokenService;
+import kr.co.mapspring.user.dto.TokenDto;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.repository.UserRepository;
+import kr.co.mapspring.user.service.TokenService;
+
+@Service
+public class TokenServiceImpl implements TokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final RefreshTokenService refreshTokenService;
+
+    private final UserRepository userRepository;
+
+    public TokenServiceImpl(
+            JwtTokenProvider jwtTokenProvider,
+            RefreshTokenService refreshTokenService,
+            UserRepository userRepository
+    ) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenService = refreshTokenService;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public TokenDto.ResponseReissue reissue(TokenDto.RequestReissue request) {
+        String refreshToken = request.getRefreshToken();
+
+        if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
+
+        if (!refreshTokenService.isRefreshTokenMatched(userId, refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.isActive()) {
+            throw new CustomException(ErrorCode.INACTIVE_USER);
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(user);
+
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+
+        return TokenDto.ResponseReissue.of(newAccessToken, newRefreshToken);
+    }
 }

--- a/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/mapspring/user/controller/AuthControllerTest.java
@@ -19,11 +19,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import kr.co.mapspring.global.exception.CustomException;
 import kr.co.mapspring.global.exception.ErrorCode;
 import kr.co.mapspring.global.exception.GlobalExceptionHandler;
+import kr.co.mapspring.global.jwt.JwtAuthenticationFilter;
 import kr.co.mapspring.user.dto.LoginDto;
 import kr.co.mapspring.user.dto.SignUpDto;
+import kr.co.mapspring.user.dto.TokenDto;
 import kr.co.mapspring.user.service.LoginService;
 import kr.co.mapspring.user.service.SignUpService;
-import kr.co.mapspring.global.jwt.JwtAuthenticationFilter;
+import kr.co.mapspring.user.service.TokenService;
 
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -44,6 +46,10 @@ class AuthControllerTest {
     // JWT 필터는 이 컨트롤러 테스트의 검증 대상이 아니므로 mock 처리한다.
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+    
+    // 토큰 서비스 mock
+    @MockitoBean
+    private TokenService tokenService;
 
     @Test
     @DisplayName("로그인 요청이 성공하면 공통 성공 응답을 반환한다")
@@ -386,4 +392,58 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("개인정보 수집 및 이용 동의는 필수입니다."));
     }
+    
+    @Test
+    @DisplayName("Refresh Token이 유효하면 Access Token과 Refresh Token 재발급 성공 응답을 반환한다")
+    void reissueTokenSuccess() throws Exception {
+        // given
+        TokenDto.ResponseReissue response = TokenDto.ResponseReissue.builder()
+                .accessToken("new-access-token")
+                .refreshToken("new-refresh-token")
+                .build();
+
+        given(tokenService.reissue(ArgumentMatchers.any(TokenDto.RequestReissue.class)))
+                .willReturn(response);
+
+        String requestBody = """
+                {
+                  "refreshToken": "valid-refresh-token"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/tokens")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("토큰 재발급 성공"))
+                .andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("new-refresh-token"));
+    }
+    
+    @Test
+    @DisplayName("Refresh Token이 유효하지 않으면 401 실패 응답을 반환한다")
+    void reissueTokenFailWhenRefreshTokenInvalid() throws Exception {
+        // given
+        given(tokenService.reissue(ArgumentMatchers.any(TokenDto.RequestReissue.class)))
+                .willThrow(new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+        String requestBody = """
+                {
+                  "refreshToken": "invalid-refresh-token"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/auth/tokens")
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("Refresh Token이 유효하지 않습니다."));
+    }
+    
 }

--- a/src/test/java/kr/co/mapspring/user/service/TokenServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/TokenServiceTest.java
@@ -1,0 +1,205 @@
+package kr.co.mapspring.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+import kr.co.mapspring.global.jwt.JwtTokenProvider;
+import kr.co.mapspring.global.jwt.RefreshTokenService;
+import kr.co.mapspring.user.dto.TokenDto;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.repository.UserRepository;
+import kr.co.mapspring.user.service.impl.TokenServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+public class TokenServiceTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TokenServiceImpl tokenService;
+
+    @Test
+    @DisplayName("유효한 Refresh Token이면 새로운 Access Token과 Refresh Token을 발급한다")
+    void reissueSuccess() {
+        // given
+        String oldRefreshToken = "old-refresh-token";
+        String newAccessToken = "new-access-token";
+        String newRefreshToken = "new-refresh-token";
+
+        TokenDto.RequestReissue request = new TokenDto.RequestReissue(oldRefreshToken);
+
+        User user = createUser();
+
+        // 기존 Refresh Token 자체가 유효하다고 가정한다.
+        given(jwtTokenProvider.validateRefreshToken(oldRefreshToken))
+                .willReturn(true);
+
+        // Refresh Token에서 userId를 꺼낸다고 가정한다.
+        given(jwtTokenProvider.getUserId(oldRefreshToken))
+                .willReturn(1L);
+
+        // Redis에 저장된 Refresh Token과 요청 Refresh Token이 같다고 가정한다.
+        given(refreshTokenService.isRefreshTokenMatched(1L, oldRefreshToken))
+                .willReturn(true);
+
+        // userId로 사용자 조회가 성공한다고 가정한다.
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        // 새 Access Token이 발급된다고 가정한다.
+        given(jwtTokenProvider.createAccessToken(user))
+                .willReturn(newAccessToken);
+
+        // 새 Refresh Token이 발급된다고 가정한다.
+        given(jwtTokenProvider.createRefreshToken(user))
+                .willReturn(newRefreshToken);
+
+        // when
+        TokenDto.ResponseReissue response = tokenService.reissue(request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getAccessToken()).isEqualTo(newAccessToken);
+        assertThat(response.getRefreshToken()).isEqualTo(newRefreshToken);
+
+        // 새 Refresh Token이 Redis 저장 서비스로 전달됐는지 확인한다.
+        verify(refreshTokenService).saveRefreshToken(1L, newRefreshToken);
+    }
+
+    @Test
+    @DisplayName("Refresh Token 자체가 유효하지 않으면 예외가 발생한다")
+    void reissueFailWhenRefreshTokenInvalid() {
+        // given
+        String refreshToken = "invalid-refresh-token";
+        TokenDto.RequestReissue request = new TokenDto.RequestReissue(refreshToken);
+
+        given(jwtTokenProvider.validateRefreshToken(refreshToken))
+                .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.reissue(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.INVALID_REFRESH_TOKEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 Refresh Token과 일치하지 않으면 예외가 발생한다")
+    void reissueFailWhenRefreshTokenDoesNotMatchRedisValue() {
+        // given
+        String refreshToken = "valid-but-not-matched-refresh-token";
+        TokenDto.RequestReissue request = new TokenDto.RequestReissue(refreshToken);
+
+        given(jwtTokenProvider.validateRefreshToken(refreshToken))
+                .willReturn(true);
+
+        given(jwtTokenProvider.getUserId(refreshToken))
+                .willReturn(1L);
+
+        given(refreshTokenService.isRefreshTokenMatched(1L, refreshToken))
+                .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.reissue(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.INVALID_REFRESH_TOKEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않으면 예외가 발생한다")
+    void reissueFailWhenUserNotFound() {
+        // given
+        String refreshToken = "valid-refresh-token";
+        TokenDto.RequestReissue request = new TokenDto.RequestReissue(refreshToken);
+
+        given(jwtTokenProvider.validateRefreshToken(refreshToken))
+                .willReturn(true);
+
+        given(jwtTokenProvider.getUserId(refreshToken))
+                .willReturn(1L);
+
+        given(refreshTokenService.isRefreshTokenMatched(1L, refreshToken))
+                .willReturn(true);
+
+        given(userRepository.findById(1L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.reissue(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("사용자 상태가 ACTIVE가 아니면 토큰 재발급에 실패한다")
+    void reissueFailWhenUserInactive() {
+        // given
+        String refreshToken = "valid-refresh-token";
+        TokenDto.RequestReissue request = new TokenDto.RequestReissue(refreshToken);
+
+        User inactiveUser = createInactiveUser();
+
+        given(jwtTokenProvider.validateRefreshToken(refreshToken))
+                .willReturn(true);
+
+        given(jwtTokenProvider.getUserId(refreshToken))
+                .willReturn(1L);
+
+        given(refreshTokenService.isRefreshTokenMatched(1L, refreshToken))
+                .willReturn(true);
+
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(inactiveUser));
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.reissue(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.INACTIVE_USER.getMessage());
+    }
+
+    private User createUser() {
+        User user = User.create(
+                "test@naver.com",
+                "홍길동",
+                LocalDate.of(2000, 1, 1),
+                "서울시 강남구",
+                "010-1234-5678",
+                "encodedPassword"
+        );
+
+        // 테스트에서는 DB 저장이 없으므로 userId가 자동 생성되지 않는다.
+        ReflectionTestUtils.setField(user, "userId", 1L);
+
+        return user;
+    }
+
+    private User createInactiveUser() {
+        User user = createUser();
+
+        // ACTIVE -> INACTIVE 상태로 변경
+        user.deactivate();
+
+        return user;
+    }
+}


### PR DESCRIPTION
## 작업내용
- token 관련 패키지 생성 (dto, service, impl)
- 관련 예외처리 추가
- 관련 로직 추가(토큰 재발급)
- 관련 test 코드 추가 
- swagger Authorize 버튼 추가

## 변경사항
- OpenApiConfig.java 추가
- -Swagger UI에서 JWT Bearer Token을 입력할 수 있도록 `bearerAuth` 설정 추가
-  Refresh Token 유효성 검증(validateRefreshToken) 추가
- Refresh Token 기반 Access Token 및 Refresh Token 재발급 로직 구현
- 요청 Refresh Token과 Redis 저장값 비교 로직 추가



## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="591" height="160" alt="image" src="https://github.com/user-attachments/assets/2b91d9ae-7cb2-4f97-bf6c-a662a563fd07" />
<img width="524" height="136" alt="image" src="https://github.com/user-attachments/assets/45f586f5-9ebd-404b-ae34-706282d256f4" />
<img width="1118" height="222" alt="image" src="https://github.com/user-attachments/assets/29390efc-aff8-4b81-af5f-362b864bbd10" />

**"accessToken": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiIxIiwiZW1haWwiOiJ0ZXN0QG5hdmVyLmNvbSIsInJvbGUiOiJVU0VSIiwidG9rZW5UeXBlIjoiQUNDRVNTIiwiaWF0IjoxNzc3MzU3MDMyLCJleHAiOjE3NzczNjA2MzJ9.B8bFfrbpNx5sJz6FZicN3CM8Yu71wAktksB9IKia1mN7GbZNnzisG6ZxzRO_8NKH"**

**"refreshToken": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiIxIiwidG9rZW5UeXBlIjoiUkVGUkVTSCIsImlhdCI6MTc3NzM1NzAzMiwiZXhwIjoxNzc3OTYxODMyfQ.X-u1ru5Jg_buj1BLU1GRoNfXthhFfoE958YCkghJL0c5J2ac4BSnHd-kuEwQBL74"**
<img width="1105" height="67" alt="image" src="https://github.com/user-attachments/assets/88c6d594-3843-4124-bca5-23183637809b" />
Redis에서의 값 일치 확인 
<img width="270" height="45" alt="image" src="https://github.com/user-attachments/assets/65e0d5dd-a0f1-44d2-88b0-d3b1118afdf8" />
TTL 확인
<img width="971" height="530" alt="image" src="https://github.com/user-attachments/assets/ef82b553-867b-4617-aff4-e6f7429ec51f" />
토큰 재발급 성공

**"refreshToken": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiIxIiwidG9rZW5UeXBlIjoiUkVGUkVTSCIsImlhdCI6MTc3NzM1NzMzNiwiZXhwIjoxNzc3OTYyMTM2fQ.aLI9nDipTkXOWUKCDkrWCOKjA14tJAKQMXPTMPo5RHHhuqzcPpposmgSVWS1ZKZW"**

<img width="1096" height="80" alt="image" src="https://github.com/user-attachments/assets/35681369-2e82-4dcf-ab16-19a9e83ec5cb" />
Redis에서 재발급 받은 토큰값 일치하는지 확인 

<img width="961" height="470" alt="image" src="https://github.com/user-attachments/assets/5b19adb3-58fe-4507-8f7a-de02350e3e76" />
이전 refresh token 사용시 오류 확인 
<img width="963" height="522" alt="image" src="https://github.com/user-attachments/assets/c59d4901-f890-471c-81c2-f35aae949216" />
새로 받은 토큰으로 다시 발급시 확인 


## 참고사항

- 현재 JWT 인증 필터는 적용되어 있으나, 팀원들의 기존 API 작업에 영향을 주지 않기 위해 전체 API 접근은 임시로 `permitAll()` 상태로 유지했습니다

- 현재 구조에서는 토큰이 있으면 JWT 필터가 인증 정보를 세팅하고, 토큰이 없어도 기존 API 요청은 막지 않습니다

- 추후 팀원 작업이 정리되면 `/api/auth/login`, `/api/auth/signup`, Swagger 관련 경로를 제외한 API는 JWT 인증이 필요하도록 전환할 예정입니다

- Refresh Token은 Redis에 저장하며, 재발급 시마다 새 Refresh Token으로 교체하는 Rotation 방식을 적용했습니다

- 로그아웃 API는 다음 단계에서 Redis에 저장된 Refresh Token을 삭제하는 방식으로 구현할 예정입니다

