### PR TITLE
fix(social): 친구 요청 테스트 및 추천 친구 로직 오류 수정

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -57,7 +57,7 @@ public enum ErrorCode {
     COACHING_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "코칭 세션을 찾을 수 없습니다."),
     ASSISTANT_MESSAGE_REQUIRED(HttpStatus.BAD_REQUEST, "AI 메시지는 비어 있을 수 없습니다."),
     COACHING_MESSAGE_ROLE_REQUIRED(HttpStatus.BAD_REQUEST, "메시지 역할은 필수입니다."),
-    INVALID_COACHING_MESSAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 코칭 메시지입니다.");
+    INVALID_COACHING_MESSAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 코칭 메시지입니다."),
 
     // Ranking
     RANKING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 랭킹이 존재하지 않습니다."),

--- a/src/main/java/kr/co/mapspring/social/repository/FriendshipRepository.java
+++ b/src/main/java/kr/co/mapspring/social/repository/FriendshipRepository.java
@@ -15,17 +15,23 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
            SELECT COUNT(f) > 0
            FROM Friendship f
            WHERE (f.requester.userId = :requesterId AND f.addressee.userId = :addresseeId)
-              OR (f.requester.userId = :addresseeId AND f.addressee.userId = :requesterId)            
+              OR (f.requester.userId = :addresseeId AND f.addressee.userId = :requesterId)
            """)
-    boolean existsFriendshipBetween(Long requesterId, Long addresseeId);
+    boolean existsFriendshipBetween(
+            @Param("requesterId") Long requesterId,
+            @Param("addresseeId") Long addresseeId
+    );
 
     @Query("""
            SELECT f
            FROM Friendship f
            WHERE (f.requester.userId = :userId OR f.addressee.userId = :userId)
-             AND f.status = :status           
+             AND f.status = :status
            """)
-    List<Friendship> findFriendshipsByUserIdAndStatus(Long userId, FriendshipStatus status);
+    List<Friendship> findFriendshipsByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") FriendshipStatus status
+    );
 
     default List<Friendship> findAcceptedFriendshipsByUserId(Long userId) {
         return findFriendshipsByUserIdAndStatus(userId, FriendshipStatus.ACCEPTED);
@@ -35,9 +41,12 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
            SELECT f
            FROM Friendship f
            WHERE f.addressee.userId = :userId
-           AND f.status = :status
+             AND f.status = :status
            """)
-    List<Friendship> findReceivedRequestsByUserIdAndStatus(Long userId, FriendshipStatus status);
+    List<Friendship> findReceivedRequestsByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") FriendshipStatus status
+    );
 
     default List<Friendship> findReceivedRequestsByUserId(Long userId) {
         return findReceivedRequestsByUserIdAndStatus(userId, FriendshipStatus.PENDING);
@@ -47,9 +56,12 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
            SELECT f
            FROM Friendship f
            WHERE f.requester.userId = :userId
-           AND f.status = :status
+             AND f.status = :status
            """)
-    List<Friendship> findSentRequestsByUserIdAndStatus(Long userId, FriendshipStatus status);
+    List<Friendship> findSentRequestsByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") FriendshipStatus status
+    );
 
     default List<Friendship> findSentRequestsByUserId(Long userId) {
         return findSentRequestsByUserIdAndStatus(userId, FriendshipStatus.PENDING);
@@ -59,14 +71,16 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
            SELECT f
            FROM Friendship f
            WHERE (f.requester.userId = :userId OR f.addressee.userId = :userId)
-           AND f.status IN (kr.co.mapspring.social.enums.FriendshipStatus.REJECTED,
-                            kr.co.mapspring.social.enums.FriendshipStatus.BLOCKED)   
+             AND f.status IN (kr.co.mapspring.social.enums.FriendshipStatus.REJECTED,
+                              kr.co.mapspring.social.enums.FriendshipStatus.BLOCKED)
            """)
-    List<Friendship> findHistoryByUserId(Long userId);
+    List<Friendship> findHistoryByUserId(
+            @Param("userId") Long userId
+    );
 
     @Query(value = """
         SELECT *
-        FROM user u
+        FROM `user` u
         WHERE u.user_id != :userId
           AND NOT EXISTS (
               SELECT 1
@@ -77,5 +91,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
         ORDER BY RAND()
         LIMIT 5
         """, nativeQuery = true)
-    List<User> findRandomRecommendedUsers(@Param("userId") Long userId);
+    List<User> findRandomRecommendedUsers(
+            @Param("userId") Long userId
+    );
 }

--- a/src/test/java/kr/co/mapspring/social/service/FriendshipServiceTest.java
+++ b/src/test/java/kr/co/mapspring/social/service/FriendshipServiceTest.java
@@ -115,22 +115,32 @@ public class FriendshipServiceTest {
     void 이메일로_친구_요청을_보낸다() {
 
         Long requesterId = 1L;
+        Long addresseeId = 2L;
         String email = "test@test.com";
 
         User requester = mock(User.class);
         User addressee = mock(User.class);
 
-        given(userRepository.findById(requesterId))
-                .willReturn(Optional.of(requester));
+        given(addressee.getUserId()).willReturn(addresseeId);
 
         given(userRepository.findByEmail(email))
                 .willReturn(Optional.of(addressee));
 
-        given(friendshipRepository.existsFriendshipBetween(requesterId, addressee.getUserId()))
+        given(userRepository.findById(requesterId))
+                .willReturn(Optional.of(requester));
+
+        given(userRepository.findById(addresseeId))
+                .willReturn(Optional.of(addressee));
+
+        given(friendshipRepository.existsFriendshipBetween(requesterId, addresseeId))
                 .willReturn(false);
 
         friendshipService.sendFriendRequestByEmail(requesterId, email);
 
+        verify(userRepository).findByEmail(email);
+        verify(userRepository).findById(requesterId);
+        verify(userRepository).findById(addresseeId);
+        verify(friendshipRepository).existsFriendshipBetween(requesterId, addresseeId);
         verify(friendshipRepository).save(any(Friendship.class));
     }
 
@@ -402,12 +412,12 @@ public class FriendshipServiceTest {
         User recommendedUser1 = mock(User.class);
         User recommendedUser2 = mock(User.class);
 
-        given(userRepository.findRandomRecommendedUsers(userId))
+        given(friendshipRepository.findRandomRecommendedUsers(userId))
                 .willReturn(List.of(recommendedUser1, recommendedUser2));
 
         List<User> result = friendshipService.getRecommendedFriends(userId);
 
-        verify(userRepository).findRandomRecommendedUsers(userId);
+        verify(friendshipRepository).findRandomRecommendedUsers(userId);
 
         assertEquals(2, result.size());
     }


### PR DESCRIPTION
## 작업내용
- 이메일 기반 친구 요청 테스트 오류 수정
- 추천 친구 조회 테스트에서 Repository 호출 대상 수정
- fixes #63 해결 완료


## 변경사항
### 1. 이메일 친구 요청 테스트 수정
- `sendFriendRequestByEmail()` 내부에서 `sendFriendRequest()` 호출 시 발생하던 오류 해결
- `User.getUserId()` mock 설정 추가
- `userRepository.findById(addresseeId)` mock 추가
- repository 호출 흐름에 맞게 verify 로직 수정

### 2. 추천 친구 테스트 수정
- 기존 `UserRepository` → `FriendshipRepository`로 호출 대상 변경
- 서비스 로직과 테스트 코드 불일치 문제 해결

## 문제원인

### 이메일 친구 요청
- `addressee.getUserId()` mock 누락으로 `null` 반환
- 내부 로직에서 `findById(null)` 호출 → `UserNotFoundForSocialException` 발생

### 추천 친구
- 서비스에서는 `FriendshipRepository` 사용
- 테스트에서는 `UserRepository`를 사용하여 메서드 불일치 발생

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [x] 이메일 친구 요청 테스트 정상 통과
- [x] 추천 친구 테스트 정상 통과
- [x] 전체 social 테스트 정상 통과
<img width="468" height="309" alt="image" src="https://github.com/user-attachments/assets/1fd71452-7e05-41bf-80b0-b24983ca90bc" />

## 참고사항
- 서비스 로직은 정상이며, 테스트 코드의 mock 설정 및 repository 호출 대상 불일치 문제였음

