### PR TITLE
feat(admin-ranking): 관리자 랭킹 API 구현

### DIFF
--- a/src/main/java/kr/co/mapspring/ranking/controller/AdminRankingController.java
+++ b/src/main/java/kr/co/mapspring/ranking/controller/AdminRankingController.java
@@ -1,0 +1,47 @@
+package kr.co.mapspring.ranking.controller;
+
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.ranking.controller.docs.AdminRankingControllerDocs;
+import kr.co.mapspring.ranking.dto.AdminRankingDto;
+import kr.co.mapspring.ranking.dto.RankingDto;
+import kr.co.mapspring.ranking.service.AdminRankingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/rankings")
+@RequiredArgsConstructor
+public class AdminRankingController implements AdminRankingControllerDocs {
+
+    private final AdminRankingService adminRankingService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponseDTO<List<RankingDto.ResponseRanking>>> getRankings() {
+        List<RankingDto.ResponseRanking> result = adminRankingService.getRankings();
+
+        return ResponseEntity.ok(ApiResponseDTO.success("관리자 전체 랭킹 조회 성공", result));
+    }
+
+    @Override
+    @GetMapping("/weekly")
+    public ResponseEntity<ApiResponseDTO<List<RankingDto.ResponseRanking>>> getWeeklyRankings() {
+        List<RankingDto.ResponseRanking> result = adminRankingService.getWeeklyRankings();
+
+        return ResponseEntity.ok(ApiResponseDTO.success("관리자 주간 랭킹 조회 성공", result));
+    }
+
+    @Override
+    @GetMapping("/users/count")
+    public ResponseEntity<ApiResponseDTO<AdminRankingDto.ResponseTotalUserCount>> getTotalUserCount() {
+        Long totalUserCount = adminRankingService.getTotalUserCount();
+
+        AdminRankingDto.ResponseTotalUserCount result =
+                AdminRankingDto.ResponseTotalUserCount.from(totalUserCount);
+
+        return ResponseEntity.ok(ApiResponseDTO.success("전체 사용자 수 조회 성공", result));
+    }
+}

--- a/src/main/java/kr/co/mapspring/ranking/controller/docs/AdminRankingControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/ranking/controller/docs/AdminRankingControllerDocs.java
@@ -1,0 +1,105 @@
+package kr.co.mapspring.ranking.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.ranking.dto.AdminRankingDto;
+import kr.co.mapspring.ranking.dto.RankingDto;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Admin Ranking", description = "관리자 랭킹 API")
+public interface AdminRankingControllerDocs {
+
+    @Operation(
+            summary = "관리자 전체 랭킹 조회",
+            description = "관리자가 전체 사용자의 누적 점수 기준 랭킹을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "관리자 전체 랭킹 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseDTO.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "status": 200,
+                                      "message": "관리자 전체 랭킹 조회 성공",
+                                      "data": [
+                                        {
+                                          "rank": 1,
+                                          "userId": 1,
+                                          "totalScore": 300
+                                        }
+                                      ]
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<ApiResponseDTO<List<RankingDto.ResponseRanking>>> getRankings();
+
+    @Operation(
+            summary = "관리자 주간 랭킹 조회",
+            description = "관리자가 최근 7일 기준 사용자의 점수 랭킹을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "관리자 주간 랭킹 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseDTO.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "status": 200,
+                                      "message": "관리자 주간 랭킹 조회 성공",
+                                      "data": [
+                                        {
+                                          "rank": 1,
+                                          "userId": 1,
+                                          "totalScore": 150
+                                        }
+                                      ]
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<ApiResponseDTO<List<RankingDto.ResponseRanking>>> getWeeklyRankings();
+
+    @Operation(
+            summary = "전체 사용자 수 조회",
+            description = "관리자가 전체 사용자 수를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "전체 사용자 수 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponseDTO.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "status": 200,
+                                      "message": "전체 사용자 수 조회 성공",
+                                      "data": {
+                                        "totalUserCount": 10
+                                      }
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<ApiResponseDTO<AdminRankingDto.ResponseTotalUserCount>> getTotalUserCount();
+}

--- a/src/main/java/kr/co/mapspring/ranking/dto/AdminRankingDto.java
+++ b/src/main/java/kr/co/mapspring/ranking/dto/AdminRankingDto.java
@@ -1,0 +1,23 @@
+package kr.co.mapspring.ranking.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AdminRankingDto {
+
+    @Getter
+    @Builder
+    @Schema(description = "관리자 전체 사용자 수 응답 DTO")
+    public static class ResponseTotalUserCount {
+
+        @Schema(description = "전체 사용자 수", example = "10")
+        private Long totalUserCount;
+
+        public static ResponseTotalUserCount from(Long totalUserCount) {
+            return ResponseTotalUserCount.builder()
+                    .totalUserCount(totalUserCount)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/kr/co/mapspring/ranking/service/AdminRankingService.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/AdminRankingService.java
@@ -1,0 +1,34 @@
+package kr.co.mapspring.ranking.service;
+
+import kr.co.mapspring.ranking.dto.RankingDto;
+
+import java.util.List;
+
+public interface AdminRankingService {
+
+    /**
+     * 관리자가 전체 랭킹을 조회한다.
+     *
+     * 전체 사용자의 누적 점수 기준 랭킹을 조회한다.
+     *
+     * @return 전체 랭킹 목록
+     */
+    List<RankingDto.ResponseRanking> getRankings();
+
+    /**
+     * 관리자가 주간 랭킹을 조회한다.
+     *
+     * 최근 7일 기준 사용자의 점수 랭킹을 조회한다.
+     *
+     * @return 주간 랭킹 목록
+     */
+    List<RankingDto.ResponseRanking> getWeeklyRankings();
+
+    /**
+     * 관리자가 전체 사용자 수를 조회한다.
+     *
+     * @return 전체 사용자 수
+     */
+    Long getTotalUserCount();
+
+}

--- a/src/main/java/kr/co/mapspring/ranking/service/impl/AdminRankingServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/impl/AdminRankingServiceImpl.java
@@ -1,0 +1,33 @@
+package kr.co.mapspring.ranking.service.impl;
+
+import kr.co.mapspring.ranking.dto.RankingDto;
+import kr.co.mapspring.ranking.service.AdminRankingService;
+import kr.co.mapspring.ranking.service.RankingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminRankingServiceImpl implements AdminRankingService {
+
+    private final RankingService rankingService;
+
+    @Override
+    public List<RankingDto.ResponseRanking> getRankings() {
+        return rankingService.getRankings();
+    }
+
+    @Override
+    public List<RankingDto.ResponseRanking> getWeeklyRankings() {
+        return rankingService.getWeeklyRankings();
+    }
+
+    @Override
+    public Long getTotalUserCount() {
+        return rankingService.getTotalUserCount();
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/service/impl/TokenServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/TokenServiceImpl.java
@@ -1,5 +1,7 @@
 package kr.co.mapspring.user.service.impl;
 
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/kr/co/mapspring/ranking/service/AdminRankingServiceTest.java
+++ b/src/test/java/kr/co/mapspring/ranking/service/AdminRankingServiceTest.java
@@ -1,0 +1,87 @@
+package kr.co.mapspring.ranking.service;
+
+import kr.co.mapspring.ranking.dto.RankingDto;
+import kr.co.mapspring.ranking.service.impl.AdminRankingServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminRankingServiceTest {
+
+    @Mock
+    private RankingService rankingService;
+
+    @InjectMocks
+    private AdminRankingServiceImpl adminRankingService;
+
+    @Test
+    @DisplayName("관리자는 전체 랭킹을 조회한다")
+    void 관리자는_전체_랭킹을_조회한다() {
+
+        RankingDto.ResponseRanking ranking1 =
+                RankingDto.ResponseRanking.from(1, 1L, 300L);
+
+        RankingDto.ResponseRanking ranking2 =
+                RankingDto.ResponseRanking.from(2, 2L, 250L);
+
+        given(rankingService.getRankings())
+                .willReturn(List.of(ranking1, ranking2));
+
+        List<RankingDto.ResponseRanking> result =
+                adminRankingService.getRankings();
+
+        verify(rankingService).getRankings();
+
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getRank());
+        assertEquals(1L, result.get(0).getUserId());
+        assertEquals(300L, result.get(0).getTotalScore());
+    }
+
+    @Test
+    @DisplayName("관리자는 주간 랭킹을 조회한다")
+    void 관리자는_주간_랭킹을_조회한다() {
+
+        RankingDto.ResponseRanking ranking1 =
+                RankingDto.ResponseRanking.from(1, 1L, 150L);
+
+        RankingDto.ResponseRanking ranking2 =
+                RankingDto.ResponseRanking.from(2, 2L, 100L);
+
+        given(rankingService.getWeeklyRankings())
+                .willReturn(List.of(ranking1, ranking2));
+
+        List<RankingDto.ResponseRanking> result =
+                adminRankingService.getWeeklyRankings();
+
+        verify(rankingService).getWeeklyRankings();
+
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getRank());
+        assertEquals(150L, result.get(0).getTotalScore());
+    }
+
+    @Test
+    @DisplayName("관리자는 전체 사용자 수를 조회한다")
+    void 관리자는_전체_사용자_수를_조회한다() {
+
+        given(rankingService.getTotalUserCount())
+                .willReturn(10L);
+
+        Long result = adminRankingService.getTotalUserCount();
+
+        verify(rankingService).getTotalUserCount();
+
+        assertEquals(10L, result);
+    }
+}


### PR DESCRIPTION
## 작업내용
- 관리자 랭킹 API 구현
- 전체 랭킹 조회 기능 구현
- 주간 랭킹 조회 기능 구현
- 전체 사용자 수 조회 기능 구현


## 변경사항
- AdminRankingController 추가
- AdminRankingControllerDocs 추가
- AdminRankingService / AdminRankingServiceImpl 추가
- AdminRankingDto 추가
- 기존 RankingService 재사용 구조 적용


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [x] Swagger API 테스트 완료
- [x] 전체 랭킹 조회 정상 동작 확인
- [x] 주간 랭킹 조회 정상 동작 확인
- [x] 전체 사용자 수 조회 정상 동작 확인
<img width="257" height="228" alt="스크린샷 2026-04-30 093706" src="https://github.com/user-attachments/assets/4e8a6f68-a479-49f4-90be-2c746cb7ec83" />
<img width="317" height="226" alt="스크린샷 2026-04-30 093721" src="https://github.com/user-attachments/assets/11045fea-1b59-4e46-a2f2-adce392ef1b0" />
<img width="239" height="104" alt="스크린샷 2026-04-30 093733" src="https://github.com/user-attachments/assets/098d8a3a-9a6f-44ae-b4f4-69ad6389cc6d" />


## 참고사항
- 기존 사용자 랭킹 로직을 재사용하여 관리자 기능을 구현했습니다.
- 학습 점수(study_score)의 total_score 합산 기준으로 랭킹이 계산됩니다.