### PR TITLE
fix(social): 친구 요청 사용자 검증 로직 수정

### DIFF
--- a/src/main/java/kr/co/mapspring/social/controller/FriendshipController.java
+++ b/src/main/java/kr/co/mapspring/social/controller/FriendshipController.java
@@ -27,9 +27,10 @@ public class FriendshipController implements FriendshipControllerDocs {
 
     @Override
     @PostMapping("/requests")
-    public ResponseEntity<ApiResponseDTO<Void>> sendFriendRequest(@RequestBody FriendshipDto.RequestSendFriendRequest request) {
+    public ResponseEntity<ApiResponseDTO<Void>> sendFriendRequest(@RequestParam("loginUserId") Long loginUserId,
+                                                                  @RequestBody FriendshipDto.RequestSendFriendRequest request) {
         friendshipService.sendFriendRequest(
-                request.getRequesterId(),
+                loginUserId,
                 request.getAddresseeId()
         );
 
@@ -38,10 +39,11 @@ public class FriendshipController implements FriendshipControllerDocs {
 
     @Override
     @PostMapping("/requests/email")
-    public ResponseEntity<ApiResponseDTO<Void>> sendFriendRequestByEmail(@RequestBody FriendshipDto.RequestSendFriendRequestByEmail request) {
+    public ResponseEntity<ApiResponseDTO<Void>> sendFriendRequestByEmail(@RequestParam("loginUserId") Long loginUserId,
+                                                                         @RequestBody FriendshipDto.RequestSendFriendRequestByEmail request) {
 
         friendshipService.sendFriendRequestByEmail(
-                request.getRequesterId(),
+                loginUserId,
                 request.getEmail()
         );
 
@@ -51,10 +53,10 @@ public class FriendshipController implements FriendshipControllerDocs {
     @Override
     @PatchMapping("/requests/{friendshipId}/accept")
     public ResponseEntity<ApiResponseDTO<Void>> acceptFriendRequest(@PathVariable("friendshipId") Long friendshipId,
-                                                                    @RequestBody FriendshipDto.RequestHandleFriendRequest request) {
+                                                                    @RequestParam("loginUserId") Long loginUserId) {
         friendshipService.acceptFriendRequest(
                 friendshipId,
-                request.getUserId()
+                loginUserId
         );
 
         return ResponseEntity.ok(ApiResponseDTO.success("친구 요청을 수락했습니다.", null));
@@ -63,10 +65,10 @@ public class FriendshipController implements FriendshipControllerDocs {
     @Override
     @PatchMapping("/requests/{friendshipId}/reject")
     public ResponseEntity<ApiResponseDTO<Void>> rejectFriendRequest(@PathVariable("friendshipId") Long friendshipId,
-                                                                    @RequestBody FriendshipDto.RequestHandleFriendRequest request) {
+                                                                    @RequestParam("loginUserId") Long loginUserId) {
         friendshipService.rejectFriendRequest(
                 friendshipId,
-                request.getUserId()
+                loginUserId
         );
 
         return ResponseEntity.ok(ApiResponseDTO.success("친구 요청을 거절했습니다.", null));
@@ -85,10 +87,10 @@ public class FriendshipController implements FriendshipControllerDocs {
     @Override
     @DeleteMapping("/{friendshipId}")
     public ResponseEntity<ApiResponseDTO<Void>> deleteFriend(@PathVariable("friendshipId") Long friendshipId,
-                                                             @RequestBody FriendshipDto.RequestHandleFriendRequest request) {
+                                                             @RequestParam("loginUserId") Long loginUserId) {
         friendshipService.deleteFriend(
                 friendshipId,
-                request.getUserId()
+                loginUserId
         );
 
         return ResponseEntity.ok(ApiResponseDTO.success("친구를 삭제했습니다.", null));
@@ -117,8 +119,10 @@ public class FriendshipController implements FriendshipControllerDocs {
     @Override
     @PatchMapping("/{friendshipId}/block")
     public ResponseEntity<ApiResponseDTO<Void>> blockFriend(@PathVariable("friendshipId") Long friendshipId,
-                                                            @RequestBody FriendshipDto.RequestHandleFriendRequest request) {
-        friendshipService.blockFriend(friendshipId, request.getUserId());
+                                                            @RequestParam("loginUserId") Long loginUserId) {
+        friendshipService.blockFriend(
+                friendshipId,
+                loginUserId);
 
         return ResponseEntity.ok(ApiResponseDTO.success("친구를 차단했습니다.", null));
     }

--- a/src/main/java/kr/co/mapspring/social/controller/docs/FriendshipControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/social/controller/docs/FriendshipControllerDocs.java
@@ -24,53 +24,12 @@ public interface FriendshipControllerDocs {
             description = "특정 사용자에게 친구 요청을 보냅니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "친구 요청 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": true,
-                                      "status": 200,
-                                      "message": "친구 요청을 보냈습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "자기 자신에게 요청 불가",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": false,
-                                      "status": 400,
-                                      "message": "자기 자신에게 친구 요청을 보낼 수 없습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "409",
-                    description = "이미 친구 관계 존재",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": false,
-                                      "status": 409,
-                                      "message": "이미 친구 관계가 존재합니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "친구 요청 성공"),
+            @ApiResponse(responseCode = "400", description = "자기 자신에게 요청 불가"),
+            @ApiResponse(responseCode = "409", description = "이미 친구 관계 존재")
     })
     ResponseEntity<ApiResponseDTO<Void>> sendFriendRequest(
+            @RequestParam("loginUserId") Long loginUserId,
             @RequestBody(
                     description = "친구 요청 정보",
                     required = true,
@@ -79,7 +38,6 @@ public interface FriendshipControllerDocs {
                             schema = @Schema(implementation = FriendshipDto.RequestSendFriendRequest.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "requesterId": 1,
                                       "addresseeId": 2
                                     }
                                     """)
@@ -93,38 +51,11 @@ public interface FriendshipControllerDocs {
             description = "이메일을 통해 특정 사용자에게 친구 요청을 보냅니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "친구 요청 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": true,
-                                  "status": 200,
-                                  "message": "이메일로 친구 요청을 보냈습니다.",
-                                  "data": null
-                                }
-                                """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "사용자 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": false,
-                                  "status": 404,
-                                  "message": "해당 이메일의 사용자를 찾을 수 없습니다.",
-                                  "data": null
-                                }
-                                """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "친구 요청 성공"),
+            @ApiResponse(responseCode = "404", description = "사용자 없음")
     })
     ResponseEntity<ApiResponseDTO<Void>> sendFriendRequestByEmail(
+            @RequestParam("loginUserId") Long loginUserId,
             @RequestBody(
                     description = "이메일 친구 요청 정보",
                     required = true,
@@ -132,11 +63,10 @@ public interface FriendshipControllerDocs {
                             mediaType = "application/json",
                             schema = @Schema(implementation = FriendshipDto.RequestSendFriendRequestByEmail.class),
                             examples = @ExampleObject(value = """
-                                {
-                                  "requesterId": 1,
-                                  "email": "user2@test.com"
-                                }
-                                """)
+                                    {
+                                      "email": "user2@test.com"
+                                    }
+                                    """)
                     )
             )
             FriendshipDto.RequestSendFriendRequestByEmail request
@@ -147,68 +77,13 @@ public interface FriendshipControllerDocs {
             description = "받은 친구 요청을 수락합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "친구 요청 수락 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": true,
-                                      "status": 200,
-                                      "message": "친구 요청을 수락했습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": false,
-                                      "status": 403,
-                                      "message": "해당 친구 요청을 처리할 권한이 없습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "친구 요청 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": false,
-                                      "status": 404,
-                                      "message": "친구 관계를 찾을 수 없습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "친구 요청 수락 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "친구 요청 없음")
     })
     ResponseEntity<ApiResponseDTO<Void>> acceptFriendRequest(
             @PathVariable("friendshipId") Long friendshipId,
-            @RequestBody(
-                    description = "요청 처리 사용자 정보",
-                    required = true,
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = FriendshipDto.RequestHandleFriendRequest.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "userId": 2
-                                    }
-                                    """)
-                    )
-            )
-            FriendshipDto.RequestHandleFriendRequest request
+            @RequestParam("loginUserId") Long loginUserId
     );
 
     @Operation(
@@ -216,68 +91,13 @@ public interface FriendshipControllerDocs {
             description = "받은 친구 요청을 거절합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "친구 요청 거절 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": true,
-                                      "status": 200,
-                                      "message": "친구 요청을 거절했습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": false,
-                                      "status": 403,
-                                      "message": "해당 친구 요청을 처리할 권한이 없습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "친구 요청 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": false,
-                                      "status": 404,
-                                      "message": "친구 관계를 찾을 수 없습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "친구 요청 거절 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "친구 요청 없음")
     })
     ResponseEntity<ApiResponseDTO<Void>> rejectFriendRequest(
             @PathVariable("friendshipId") Long friendshipId,
-            @RequestBody(
-                    description = "요청 처리 사용자 정보",
-                    required = true,
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = FriendshipDto.RequestHandleFriendRequest.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "userId": 2
-                                    }
-                                    """)
-                    )
-            )
-            FriendshipDto.RequestHandleFriendRequest request
+            @RequestParam("loginUserId") Long loginUserId
     );
 
     @Operation(
@@ -285,98 +105,24 @@ public interface FriendshipControllerDocs {
             description = "사용자의 친구 목록을 조회합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": true,
-                                      "status": 200,
-                                      "message": "친구 목록 조회 성공",
-                                      "data": [
-                                        {
-                                          "friendshipId": 1,
-                                          "requesterId": 1,
-                                          "addresseeId": 2,
-                                          "status": "ACCEPTED"
-                                        }
-                                      ]
-                                    }
-                                    """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "조회 성공")
     })
-    ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getFriends(@RequestParam("userId") Long userId);
+    ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getFriends(
+            @RequestParam("userId") Long userId
+    );
 
     @Operation(
             summary = "친구 삭제",
             description = "친구 관계를 삭제합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "친구 삭제 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": true,
-                                      "status": 200,
-                                      "message": "친구를 삭제했습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": false,
-                                      "status": 403,
-                                      "message": "해당 친구 요청을 처리할 권한이 없습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "친구 관계 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "success": false,
-                                      "status": 404,
-                                      "message": "친구 관계를 찾을 수 없습니다.",
-                                      "data": null
-                                    }
-                                    """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "친구 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "친구 관계 없음")
     })
     ResponseEntity<ApiResponseDTO<Void>> deleteFriend(
             @PathVariable("friendshipId") Long friendshipId,
-            @RequestBody(
-                    description = "삭제 요청 사용자 정보",
-                    required = true,
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = FriendshipDto.RequestHandleFriendRequest.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "userId": 1
-                                    }
-                                    """)
-                    )
-            )
-            FriendshipDto.RequestHandleFriendRequest request
+            @RequestParam("loginUserId") Long loginUserId
     );
 
     @Operation(
@@ -384,112 +130,37 @@ public interface FriendshipControllerDocs {
             description = "사용자가 받은 친구 요청(PENDING 상태)을 조회합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": true,
-                                  "status": 200,
-                                  "message": "받은 친구 요청 조회 성공",
-                                  "data": [
-                                    {
-                                      "friendshipId": 1,
-                                      "requesterId": 2,
-                                      "addresseeId": 1,
-                                      "status": "PENDING"
-                                    }
-                                  ]
-                                }
-                                """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": false,
-                                  "status": 400,
-                                  "message": "userId는 필수입니다.",
-                                  "data": null
-                                }
-                                """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
-    ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getReceivedRequests(@RequestParam("userId") Long userId);
+    ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getReceivedRequests(
+            @RequestParam("userId") Long userId
+    );
 
     @Operation(
             summary = "보낸 친구 요청 목록 조회",
             description = "사용자가 보낸 친구 요청(PENDING 상태)을 조회합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": true,
-                                  "status": 200,
-                                  "message": "보낸 친구 요청 조회 성공",
-                                  "data": [
-                                    {
-                                      "friendshipId": 1,
-                                      "requesterId": 1,
-                                      "addresseeId": 2,
-                                      "status": "PENDING"
-                                    }
-                                  ]
-                                }
-                                """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": false,
-                                  "status": 400,
-                                  "message": "userId는 필수입니다.",
-                                  "data": null
-                                }
-                                """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
-    ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getSentRequests(@RequestParam("userId") Long userId);
+    ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getSentRequests(
+            @RequestParam("userId") Long userId
+    );
 
     @Operation(
             summary = "친구 차단",
             description = "특정 친구 관계를 차단 상태로 변경합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "차단 성공"
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음"
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "친구 관계 없음"
-            )
+            @ApiResponse(responseCode = "200", description = "차단 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "친구 관계 없음")
     })
     ResponseEntity<ApiResponseDTO<Void>> blockFriend(
             @PathVariable("friendshipId") Long friendshipId,
-            @RequestBody FriendshipDto.RequestHandleFriendRequest request
+            @RequestParam("loginUserId") Long loginUserId
     );
 
     @Operation(
@@ -497,34 +168,7 @@ public interface FriendshipControllerDocs {
             description = "사용자와 관련된 친구 관계 중 REJECTED, BLOCKED 상태의 이력을 조회합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": true,
-                                  "status": 200,
-                                  "message": "차단 및 거절 이력 조회 성공",
-                                  "data": [
-                                    {
-                                      "friendshipId": 1,
-                                      "requesterId": 2,
-                                      "addresseeId": 1,
-                                      "status": "REJECTED"
-                                    },
-                                    {
-                                      "friendshipId": 2,
-                                      "requesterId": 1,
-                                      "addresseeId": 3,
-                                      "status": "BLOCKED"
-                                    }
-                                  ]
-                                }
-                                """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "조회 성공")
     })
     ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getFriendshipHistory(
             @RequestParam("userId") Long userId
@@ -535,42 +179,8 @@ public interface FriendshipControllerDocs {
             description = "친구 관계가 없는 사용자를 랜덤으로 추천합니다."
     )
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "추천 친구 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": true,
-                                  "status": 200,
-                                  "message": "추천 친구 조회 성공",
-                                  "data": [
-                                    {
-                                      "userId": 2,
-                                      "name": "유저2",
-                                      "email": "user2@test.com"
-                                    }
-                                  ]
-                                }
-                                """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                {
-                                  "success": false,
-                                  "status": 400,
-                                  "message": "userId는 필수입니다.",
-                                  "data": null
-                                }
-                                """)
-                    )
-            )
+            @ApiResponse(responseCode = "200", description = "추천 친구 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseRecommendedFriend>>> getRecommendedFriends(
             @RequestParam("userId") Long userId

--- a/src/main/java/kr/co/mapspring/social/dto/FriendshipDto.java
+++ b/src/main/java/kr/co/mapspring/social/dto/FriendshipDto.java
@@ -15,9 +15,6 @@ public class FriendshipDto {
     @Schema(description = "친구 요청 전송 요청 DTO")
     public static class RequestSendFriendRequest {
 
-        @Schema(description = "요청 보내는 사용자 ID", example = "1")
-        private Long requesterId;
-
         @Schema(description = "요청 받는 사용자 ID", example = "2")
         private Long addresseeId;
     }
@@ -27,20 +24,8 @@ public class FriendshipDto {
     @Schema(description = "이메일 친구 요청 DTO")
     public static class RequestSendFriendRequestByEmail {
 
-        @Schema(description = "요청 보내는 사용자 ID", example = "1")
-        private Long requesterId;
-
         @Schema(description = "요청 받는 사용자 이메일", example = "user2@test.com")
         private String email;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    @Schema(description = "친구 요청 처리 요청 DTO")
-    public static class RequestHandleFriendRequest {
-
-        @Schema(description = "사용자 ID", example = "2")
-        private Long userId;
     }
 
     @Getter

--- a/src/test/java/kr/co/mapspring/social/service/FriendshipServiceTest.java
+++ b/src/test/java/kr/co/mapspring/social/service/FriendshipServiceTest.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;


### PR DESCRIPTION
## 작업내용
- 친구 요청 시 requesterId를 request body에서 제거
- 로그인 사용자 기준으로 요청자를 처리하도록 로직 수정
- 친구 요청 / 수락 / 거절 / 삭제 / 차단 API에서 userId 조작 방지
- Swagger 요청 형식 및 예시 수정
- fixes: #83 해결


## 변경사항
### Before
- requesterId, userId를 request body로 전달
- 사용자 임의 조작 가능 (보안 취약점)

### After
- loginUserId를 RequestParam으로 전달
- 서버 기준 사용자 검증으로 변경


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [x] 친구 요청 정상 동작 확인
- [x] 중복 요청 시 409 반환 확인
- [x] 친구 요청 수락/거절 정상 동작 확인
- [x] 잘못된 사용자로 요청 시 권한 예외 발생 확인


## 참고사항
- 현재 인증(JWT) 미적용 상태로, 임시로 RequestParam을 사용하여 사용자 식별
- 추후 Security 적용 시 @AuthenticationPrincipal 방식으로 변경 예정

