### PR TITLE
fix(social): 사용자 중복 신고 방지 로직 추가

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -45,7 +45,8 @@ public enum ErrorCode {
     FRIENDSHIP_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 친구 관계가 존재합니다."),
     FRIENDSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 관계를 찾을 수 없습니다."),
     FRIEND_REQUEST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 친구 요청을 처리할 권한이 없습니다."),
-  
+    DUPLICATE_USER_REPORT(HttpStatus.CONFLICT, "이미 해당 사용자를 신고했습니다."),
+
     // Learning Goal
     GOAL_MASTER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 학습 목표입니다."),
     GOAL_ALREADY_SELECTED(HttpStatus.CONFLICT, "이미 선택한 학습 목표입니다."),

--- a/src/main/java/kr/co/mapspring/global/exception/social/DuplicateUserReportException.java
+++ b/src/main/java/kr/co/mapspring/global/exception/social/DuplicateUserReportException.java
@@ -1,0 +1,10 @@
+package kr.co.mapspring.global.exception.social;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+public class DuplicateUserReportException extends CustomException {
+    public DuplicateUserReportException() {
+        super(ErrorCode.DUPLICATE_USER_REPORT);
+    }
+}

--- a/src/main/java/kr/co/mapspring/social/repository/UserReportRepository.java
+++ b/src/main/java/kr/co/mapspring/social/repository/UserReportRepository.java
@@ -10,4 +10,6 @@ public interface UserReportRepository extends JpaRepository<UserReport, Long> {
     List<UserReport> findByReporter_UserId(Long userId);
 
     List<UserReport> findAllByOrderByCreatedAtDesc();
+
+    boolean existsByReporter_UserIdAndReportedUser_UserId(Long reporterId, Long reportedUserId);
 }

--- a/src/main/java/kr/co/mapspring/social/service/impl/UserReportServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/social/service/impl/UserReportServiceImpl.java
@@ -1,9 +1,6 @@
 package kr.co.mapspring.social.service.impl;
 
-import kr.co.mapspring.global.exception.social.InvalidReportReasonException;
-import kr.co.mapspring.global.exception.social.InvalidReportUserException;
-import kr.co.mapspring.global.exception.social.SelfReportNotAllowedException;
-import kr.co.mapspring.global.exception.social.UserNotFoundForSocialException;
+import kr.co.mapspring.global.exception.social.*;
 import kr.co.mapspring.social.entity.UserReport;
 import kr.co.mapspring.social.repository.UserReportRepository;
 import kr.co.mapspring.social.service.UserReportService;
@@ -37,6 +34,10 @@ public class UserReportServiceImpl implements UserReportService {
 
         if (reason == null || reason.isBlank()) {
             throw new InvalidReportReasonException();
+        }
+
+        if (userReportRepository.existsByReporter_UserIdAndReportedUser_UserId(reporterId, reportedUserId)) {
+            throw new DuplicateUserReportException();
         }
 
         User reporter = userRepository.findById(reporterId)


### PR DESCRIPTION
## 작업내용
- 동일 사용자가 같은 사용자를 여러 번 신고하지 못하도록 중복 신고 검증 추가
- 중복 신고 시 예외 처리 추가
- 신고 저장 전 reporterId/reportedUserId 조합 중복 여부 확인
- fixes: #84 해결


## 변경사항
### Before
- 동일 reporter가 같은 reportedUser를 여러 번 신고 가능
- 중복 데이터 저장 가능 (비즈니스 로직 문제)

### After
- reporterId + reportedUserId 기준 중복 신고 검증 추가
- 이미 신고한 경우 예외 발생 (409 CONFLICT)


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [x] 동일 reporterId → reportedUserId 중복 신고 시 예외 반환 확인
<img width="378" height="127" alt="image" src="https://github.com/user-attachments/assets/9fc97682-1501-4920-ad0a-642e5e8ac1d5" />



## 참고사항
- 같은 reporterId와 reportedUserId 조합은 1회만 신고 가능하도록 처리했습니다.

