### PR TITLE
feat(auth): Refresh Token 전달 방식을 HttpOnly Cookie로 전환

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
 	
 	// JWT 토큰용
 	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
+	INVALID_OAUTH_LOGIN_CODE(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 OAuth 로그인 코드입니다."),
 
     // Favorite Place
     FAVORITE_PLACE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기한 장소입니다."),

--- a/src/main/java/kr/co/mapspring/global/jwt/AuthCookieService.java
+++ b/src/main/java/kr/co/mapspring/global/jwt/AuthCookieService.java
@@ -1,0 +1,101 @@
+package kr.co.mapspring.global.jwt;
+
+import java.time.Duration;
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+
+@Service
+public class AuthCookieService {
+
+    @Value("${auth.cookie.refresh-token-name:refreshToken}")
+    private String refreshTokenCookieName;
+
+    @Value("${auth.cookie.path:/}")
+    private String cookiePath;
+
+    @Value("${auth.cookie.domain:}")
+    private String cookieDomain;
+
+    @Value("${auth.cookie.secure:false}")
+    private boolean secure;
+
+    @Value("${auth.cookie.http-only:true}")
+    private boolean httpOnly;
+
+    @Value("${auth.cookie.same-site:Lax}")
+    private String sameSite;
+
+    @Value("${jwt.refresh-token-expiration:604800000}")
+    private long refreshTokenExpirationMs;
+
+    /*
+     * Refresh Token을 HttpOnly Cookie로 생성합니다.
+     * 프론트 JavaScript에서는 이 쿠키를 읽을 수 없습니다.
+     */
+    public ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie
+                .from(refreshTokenCookieName, refreshToken)
+                .httpOnly(httpOnly)
+                .secure(secure)
+                .path(cookiePath)
+                .sameSite(sameSite)
+                .maxAge(Duration.ofMillis(refreshTokenExpirationMs));
+
+        /*
+         * 로컬 localhost 환경에서는 domain을 명시하지 않는 것이 안전합니다.
+         * domain을 비워두면 host-only cookie로 생성됩니다.
+         */
+        if (StringUtils.hasText(cookieDomain)) {
+            builder.domain(cookieDomain);
+        }
+
+        return builder.build();
+    }
+
+    /*
+     * 로그아웃 시 Refresh Token 쿠키를 즉시 만료시키기 위한 쿠키를 생성합니다.
+     */
+    public ResponseCookie deleteRefreshTokenCookie() {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie
+                .from(refreshTokenCookieName, "")
+                .httpOnly(httpOnly)
+                .secure(secure)
+                .path(cookiePath)
+                .sameSite(sameSite)
+                .maxAge(0);
+
+        if (StringUtils.hasText(cookieDomain)) {
+            builder.domain(cookieDomain);
+        }
+
+        return builder.build();
+    }
+
+    /*
+     * 요청 Cookie에서 Refresh Token 값을 추출합니다.
+     * 없으면 INVALID_REFRESH_TOKEN 예외를 발생시킵니다.
+     */
+    public String extractRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> refreshTokenCookieName.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .filter(StringUtils::hasText)
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/controller/AuthController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/AuthController.java
@@ -1,12 +1,16 @@
 package kr.co.mapspring.user.controller;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.global.jwt.AuthCookieService;
 import kr.co.mapspring.user.controller.docs.AuthControllerDocs;
 import kr.co.mapspring.user.dto.LoginDto;
 import kr.co.mapspring.user.dto.SignUpDto;
@@ -26,55 +30,116 @@ public class AuthController implements AuthControllerDocs {
 
     // 회원가입 서비스
     private final SignUpService signUpService;
-    
-    // 토큰 서비스
+
+    // 토큰 재발급 / 로그아웃 서비스
     private final TokenService tokenService;
+
+    // Refresh Token Cookie 생성 / 추출 / 삭제 담당
+    private final AuthCookieService authCookieService;
 
     @Override
     @PostMapping("/login")
     public ApiResponseDTO<LoginDto.ResponseLogin> login(
-            @RequestBody LoginDto.RequestLogin request
+            @Valid @RequestBody LoginDto.RequestLogin request,
+            HttpServletResponse httpServletResponse
     ) {
-        // 로그인 서비스 호출
+        /*
+         * 로그인 성공 시 accessToken + refreshToken이 생성됩니다.
+         * 단, refreshToken은 JSON 응답에 노출하지 않고 HttpOnly Cookie로 내려보냅니다.
+         */
         LoginDto.ResponseLogin response = loginService.login(request);
 
-        // 공통 성공 응답 반환
+        /*
+         * refreshToken을 HttpOnly Cookie로 설정합니다.
+         * LoginDto.ResponseLogin의 refreshToken 필드는 @JsonIgnore 처리되어
+         * 응답 body에는 포함되지 않습니다.
+         */
+        httpServletResponse.addHeader(
+                HttpHeaders.SET_COOKIE,
+                authCookieService.createRefreshTokenCookie(response.getRefreshToken()).toString()
+        );
+
+        /*
+         * 응답 body에는 accessToken만 포함됩니다.
+         */
         return ApiResponseDTO.success("로그인 성공", response);
     }
 
     @Override
     @PostMapping("/signup")
     public ApiResponseDTO<SignUpDto.ResponseSignUp> signUp(
-            @RequestBody SignUpDto.RequestSignUp request
+            @Valid @RequestBody SignUpDto.RequestSignUp request
     ) {
-        // 회원가입 서비스 호출
+        /*
+         * 회원가입 요청값 검증은 DTO의 Bean Validation과
+         * SignUpService의 비즈니스 검증에서 처리합니다.
+         */
         SignUpDto.ResponseSignUp response = signUpService.signUp(request);
 
-        // 공통 성공 응답 반환
         return ApiResponseDTO.success("회원가입 성공", response);
     }
-    
+
     @Override
     @PostMapping("/tokens")
     public ApiResponseDTO<TokenDto.ResponseReissue> reissueToken(
-            @Valid @RequestBody TokenDto.RequestReissue request
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse
     ) {
-        // Refresh Token 기반 토큰 재발급 서비스 호출
+        /*
+         * 기존 방식:
+         * - request body에서 refreshToken을 받음
+         *
+         * 변경 방식:
+         * - HttpOnly Cookie에서 refreshToken을 추출함
+         */
+        String refreshToken = authCookieService.extractRefreshToken(httpServletRequest);
+
+        /*
+         * 기존 TokenService 시그니처를 유지하기 위해
+         * Cookie에서 꺼낸 refreshToken으로 RequestReissue DTO를 생성합니다.
+         */
+        TokenDto.RequestReissue request = new TokenDto.RequestReissue(refreshToken);
+
         TokenDto.ResponseReissue response = tokenService.reissue(request);
 
-        // 공통 성공 응답 반환
+        /*
+         * Refresh Token Rotation 후 새 refreshToken을 다시 HttpOnly Cookie로 내려보냅니다.
+         * ResponseReissue의 refreshToken 필드는 @JsonIgnore 처리되어 body에는 노출되지 않습니다.
+         */
+        httpServletResponse.addHeader(
+                HttpHeaders.SET_COOKIE,
+                authCookieService.createRefreshTokenCookie(response.getRefreshToken()).toString()
+        );
+
         return ApiResponseDTO.success("토큰 재발급 성공", response);
     }
+
     @Override
     @PostMapping("/logout")
     public ApiResponseDTO<Void> logout(
-            @Valid @RequestBody TokenDto.RequestLogout request
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse
     ) {
-        // Refresh Token 검증 후 Redis에서 삭제
+        /*
+         * 로그아웃도 request body가 아니라 Cookie에서 refreshToken을 추출합니다.
+         */
+        String refreshToken = authCookieService.extractRefreshToken(httpServletRequest);
+
+        TokenDto.RequestLogout request = new TokenDto.RequestLogout(refreshToken);
+
+        /*
+         * Redis에 저장된 refresh:{userId} 값을 삭제합니다.
+         */
         tokenService.logout(request);
 
-        // 공통 성공 응답 반환
+        /*
+         * 브라우저의 refreshToken Cookie도 만료시킵니다.
+         */
+        httpServletResponse.addHeader(
+                HttpHeaders.SET_COOKIE,
+                authCookieService.deleteRefreshTokenCookie().toString()
+        );
+
         return ApiResponseDTO.success("로그아웃 성공");
     }
-    
 }

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AuthControllerDocs.java
@@ -1,13 +1,15 @@
 package kr.co.mapspring.user.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import kr.co.mapspring.global.dto.ApiResponseDTO;
 import kr.co.mapspring.user.dto.LoginDto;
 import kr.co.mapspring.user.dto.SignUpDto;
@@ -18,7 +20,11 @@ public interface AuthControllerDocs {
 
     @Operation(
             summary = "로그인",
-            description = "이메일과 비밀번호를 입력받아 로그인 처리하고 사용자 정보 및 토큰 정보를 반환합니다."
+            description = """
+                    이메일과 비밀번호를 입력받아 로그인 처리합니다.
+                    로그인 성공 시 Access Token은 응답 body로 반환하고,
+                    Refresh Token은 HttpOnly Cookie로 설정합니다.
+                    """
     )
     @ApiResponses({
             @ApiResponse(
@@ -38,8 +44,7 @@ public interface AuthControllerDocs {
                                                 "email": "test@naver.com",
                                                 "name": "홍길동",
                                                 "role": "USER",
-                                                "accessToken": "<ACCESS_TOKEN>",
-                                                "refreshToken": "<REFRESH_TOKEN>"
+                                                "accessToken": "<ACCESS_TOKEN>"
                                               }
                                             }
                                             """
@@ -102,7 +107,7 @@ public interface AuthControllerDocs {
             )
     })
     ApiResponseDTO<LoginDto.ResponseLogin> login(
-            @RequestBody(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "로그인 요청 정보",
                     required = true,
                     content = @Content(
@@ -112,13 +117,16 @@ public interface AuthControllerDocs {
                                     value = """
                                             {
                                               "email": "test@naver.com",
-                                              "password": "1234"
+                                              "password": "Password123!"
                                             }
                                             """
                             )
                     )
             )
-            LoginDto.RequestLogin request
+            LoginDto.RequestLogin request,
+
+            @Parameter(hidden = true)
+            HttpServletResponse httpServletResponse
     );
 
     @Operation(
@@ -168,7 +176,7 @@ public interface AuthControllerDocs {
                                     ),
                                     @ExampleObject(
                                             name = "입력값 검증 실패",
-                                            summary = "생년월일 형식 오류 등 요청값 검증에 실패한 경우",
+                                            summary = "요청값 검증에 실패한 경우",
                                             value = """
                                                     {
                                                       "success": false,
@@ -258,7 +266,7 @@ public interface AuthControllerDocs {
             )
     })
     ApiResponseDTO<SignUpDto.ResponseSignUp> signUp(
-            @RequestBody(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "회원가입 요청 정보",
                     required = true,
                     content = @Content(
@@ -272,8 +280,8 @@ public interface AuthControllerDocs {
                                               "address": "서울시 강남구",
                                               "phoneNumber": "010-0000-0001",
                                               "email": "test@test1.com",
-                                              "password": "1234",
-                                              "passwordConfirm": "1234",
+                                              "password": "Password123!",
+                                              "passwordConfirm": "Password123!",
                                               "serviceAgree": true,
                                               "privacyAgree": true,
                                               "marketingAgree": false
@@ -286,8 +294,12 @@ public interface AuthControllerDocs {
     );
 
     @Operation(
-            summary = "Access Token 및 Refresh Token 재발급",
-            description = "Refresh Token을 검증한 뒤 새로운 Access Token과 Refresh Token을 발급합니다."
+            summary = "Access Token 재발급",
+            description = """
+                    HttpOnly Cookie에 저장된 Refresh Token을 검증한 뒤
+                    새로운 Access Token을 발급합니다.
+                    Refresh Token Rotation으로 새 Refresh Token은 다시 HttpOnly Cookie로 설정됩니다.
+                    """
     )
     @ApiResponses({
             @ApiResponse(
@@ -303,8 +315,7 @@ public interface AuthControllerDocs {
                                               "status": 200,
                                               "message": "토큰 재발급 성공",
                                               "data": {
-                                                "accessToken": "<NEW_ACCESS_TOKEN>",
-                                                "refreshToken": "<NEW_REFRESH_TOKEN>"
+                                                "accessToken": "<NEW_ACCESS_TOKEN>"
                                               }
                                             }
                                             """
@@ -349,27 +360,20 @@ public interface AuthControllerDocs {
             )
     })
     ApiResponseDTO<TokenDto.ResponseReissue> reissueToken(
-            @RequestBody(
-                    description = "토큰 재발급 요청 정보",
-                    required = true,
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = TokenDto.RequestReissue.class),
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "refreshToken": "<REFRESH_TOKEN>"
-                                            }
-                                            """
-                            )
-                    )
-            )
-            TokenDto.RequestReissue request
+            @Parameter(hidden = true)
+            HttpServletRequest httpServletRequest,
+
+            @Parameter(hidden = true)
+            HttpServletResponse httpServletResponse
     );
 
     @Operation(
             summary = "로그아웃",
-            description = "Refresh Token을 검증한 뒤 Redis에 저장된 Refresh Token을 삭제합니다."
+            description = """
+                    HttpOnly Cookie의 Refresh Token을 검증한 뒤
+                    Redis에 저장된 Refresh Token을 삭제하고,
+                    브라우저의 Refresh Token Cookie를 만료시킵니다.
+                    """
     )
     @ApiResponses({
             @ApiResponse(
@@ -410,21 +414,10 @@ public interface AuthControllerDocs {
             )
     })
     ApiResponseDTO<Void> logout(
-            @RequestBody(
-                    description = "로그아웃 요청 정보",
-                    required = true,
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = TokenDto.RequestLogout.class),
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "refreshToken": "<REFRESH_TOKEN>"
-                                            }
-                                            """
-                            )
-                    )
-            )
-            TokenDto.RequestLogout request
+            @Parameter(hidden = true)
+            HttpServletRequest httpServletRequest,
+
+            @Parameter(hidden = true)
+            HttpServletResponse httpServletResponse
     );
 }

--- a/src/main/java/kr/co/mapspring/user/dto/LoginDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/LoginDto.java
@@ -1,5 +1,7 @@
 package kr.co.mapspring.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -50,8 +52,10 @@ public class LoginDto {
         @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiJ9...")
         private String accessToken;
         
-        @Schema(description = "JWT Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        @JsonIgnore
+        @Schema(hidden = true)
         private String refreshToken;
+
 
         // Entity -> Response DTO 변환
         // 기존 테스트나 다른 코드에서 사용 할 수 있으므로 유지

--- a/src/main/java/kr/co/mapspring/user/dto/TokenDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/TokenDto.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -15,8 +16,12 @@ public class TokenDto {
     @Schema(description = "토큰 재발급 요청 DTO")
     public static class RequestReissue {
 
+        /*
+         * HttpOnly Cookie 전환 후에는 클라이언트가 직접 보내지 않습니다.
+         * Controller가 Cookie에서 꺼낸 refreshToken으로 이 DTO를 생성합니다.
+         */
         @NotBlank(message = "Refresh Token은 필수 입력 값입니다.")
-        @Schema(description = "JWT Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        @Schema(hidden = true)
         private String refreshToken;
     }
 
@@ -30,7 +35,12 @@ public class TokenDto {
         @Schema(description = "새로 발급된 JWT Access Token", example = "eyJhbGciOiJIUzI1NiJ9...")
         private String accessToken;
 
-        @Schema(description = "새로 발급된 JWT Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        /*
+         * 새 Refresh Token은 HttpOnly Cookie로 내려보냅니다.
+         * JSON 응답에는 포함하지 않습니다.
+         */
+        @JsonIgnore
+        @Schema(hidden = true)
         private String refreshToken;
 
         public static ResponseReissue of(String accessToken, String refreshToken) {
@@ -40,15 +50,19 @@ public class TokenDto {
                     .build();
         }
     }
-    
+
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     @Schema(description = "로그아웃 요청 DTO")
     public static class RequestLogout {
 
+        /*
+         * HttpOnly Cookie 전환 후에는 클라이언트가 직접 보내지 않습니다.
+         * Controller가 Cookie에서 꺼낸 refreshToken으로 이 DTO를 생성합니다.
+         */
         @NotBlank(message = "Refresh Token은 필수 입력 값입니다.")
-        @Schema(description = "JWT Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        @Schema(hidden = true)
         private String refreshToken;
     }
 }

--- a/src/main/java/kr/co/mapspring/user/oauth/controller/OauthController.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/controller/OauthController.java
@@ -1,12 +1,15 @@
 package kr.co.mapspring.user.oauth.controller;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.global.jwt.AuthCookieService;
 import kr.co.mapspring.user.oauth.controller.docs.OauthControllerDocs;
 import kr.co.mapspring.user.oauth.dto.OauthLoginDto;
 import kr.co.mapspring.user.oauth.service.OauthLoginCodeService;
@@ -19,13 +22,34 @@ public class OauthController implements OauthControllerDocs {
 
     private final OauthLoginCodeService oauthLoginCodeService;
 
+    private final AuthCookieService authCookieService;
+
     @Override
     @PostMapping("/tokens")
     public ApiResponseDTO<OauthLoginDto.ResponseToken> exchangeToken(
-            @Valid @RequestBody OauthLoginDto.RequestToken request
+            @Valid @RequestBody OauthLoginDto.RequestToken request,
+            HttpServletResponse httpServletResponse
     ) {
-        OauthLoginDto.ResponseToken response =
+        /*
+         * 프론트가 전달한 1회용 code로 Redis에 임시 저장된 토큰 정보를 조회합니다.
+         * code는 조회 후 즉시 삭제됩니다.
+         */
+        OauthLoginDto.TokenResult tokenResult =
                 oauthLoginCodeService.consumeToken(request.getCode());
+
+        /*
+         * refreshToken은 JSON body에 노출하지 않고 HttpOnly Cookie로 내려보냅니다.
+         */
+        httpServletResponse.addHeader(
+                HttpHeaders.SET_COOKIE,
+                authCookieService.createRefreshTokenCookie(tokenResult.getRefreshToken()).toString()
+        );
+
+        /*
+         * 응답 body에는 accessToken과 profileRequired만 포함됩니다.
+         */
+        OauthLoginDto.ResponseToken response =
+                OauthLoginDto.ResponseToken.from(tokenResult);
 
         return ApiResponseDTO.success("OAuth 토큰 교환 성공", response);
     }

--- a/src/main/java/kr/co/mapspring/user/oauth/controller/docs/OauthControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/controller/docs/OauthControllerDocs.java
@@ -1,9 +1,13 @@
 package kr.co.mapspring.user.oauth.controller.docs;
 
-import org.springframework.web.bind.annotation.RequestBody;
-
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
 import kr.co.mapspring.global.dto.ApiResponseDTO;
 import kr.co.mapspring.user.oauth.dto.OauthLoginDto;
 
@@ -11,9 +15,71 @@ public interface OauthControllerDocs {
 
     @Operation(
             summary = "OAuth 로그인 토큰 교환",
-            description = "Google OAuth 로그인 성공 후 발급된 1회용 code를 accessToken/refreshToken으로 교환합니다."
+            description = """
+                    Google OAuth 로그인 성공 후 발급된 1회용 code를 Access Token으로 교환합니다.
+                    Refresh Token은 응답 body에 포함하지 않고 HttpOnly Cookie로 설정합니다.
+                    """
     )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "OAuth 토큰 교환 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "OAuth 토큰 교환 성공",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "OAuth 토큰 교환 성공",
+                                              "data": {
+                                                "accessToken": "<ACCESS_TOKEN>",
+                                                "profileRequired": true
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않거나 만료된 OAuth 로그인 code",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "유효하지 않은 code",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "유효하지 않거나 만료된 OAuth 로그인 코드입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     ApiResponseDTO<OauthLoginDto.ResponseToken> exchangeToken(
-            @Valid @RequestBody OauthLoginDto.RequestToken request
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "OAuth 토큰 교환 요청 정보",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = OauthLoginDto.RequestToken.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "3f1b8f1e-4f4a-4c25-9c91-123456789abc"
+                                            }
+                                            """
+                            )
+                    )
+            )
+            OauthLoginDto.RequestToken request,
+
+            @Parameter(hidden = true)
+            HttpServletResponse httpServletResponse
     );
 }

--- a/src/main/java/kr/co/mapspring/user/oauth/dto/OauthLoginDto.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/dto/OauthLoginDto.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.user.oauth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,13 +12,15 @@ public class OauthLoginDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "OAuth 토큰 교환 요청 DTO")
     public static class RequestToken {
 
         /*
-         * OAuth 로그인 성공 후 프론트가 받은 1회용 코드입니다.
-         * 실제 accessToken/refreshToken이 아니라 Redis 임시 저장값을 찾기 위한 코드입니다.
+         * OAuth 로그인 성공 후 프론트가 받은 1회용 code입니다.
+         * 실제 accessToken/refreshToken이 아니라 Redis 임시 저장값을 찾기 위한 code입니다.
          */
-        @NotBlank
+        @NotBlank(message = "OAuth 로그인 code는 필수 입력 값입니다.")
+        @Schema(description = "OAuth 로그인 성공 후 발급된 1회용 code", example = "3f1b8f1e-4f4a-4c25-9c91-123456789abc")
         private String code;
     }
 
@@ -25,20 +28,51 @@ public class OauthLoginDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "OAuth 토큰 교환 응답 DTO")
     public static class ResponseToken {
 
+        /*
+         * 프론트가 Authorization Header에 사용할 Access Token입니다.
+         */
+        @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        private String accessToken;
+
+        /*
+         * 소셜 회원의 추가 프로필 입력 필요 여부입니다.
+         */
+        @Schema(description = "추가 프로필 입력 필요 여부", example = "true")
+        private Boolean profileRequired;
+
+        public static ResponseToken from(TokenResult tokenResult) {
+            return ResponseToken.builder()
+                    .accessToken(tokenResult.getAccessToken())
+                    .profileRequired(tokenResult.getProfileRequired())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenResult {
+
+        /*
+         * 내부 처리/Redis 저장용 DTO입니다.
+         * refreshToken이 포함되지만 API 응답 DTO로 직접 반환하지 않습니다.
+         */
         private String accessToken;
 
         private String refreshToken;
 
         private Boolean profileRequired;
 
-        public static ResponseToken of(
+        public static TokenResult of(
                 String accessToken,
                 String refreshToken,
                 Boolean profileRequired
         ) {
-            return ResponseToken.builder()
+            return TokenResult.builder()
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)
                     .profileRequired(profileRequired)

--- a/src/main/java/kr/co/mapspring/user/oauth/handler/OauthLoginSuccessHandler.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/handler/OauthLoginSuccessHandler.java
@@ -25,7 +25,7 @@ public class OauthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
     private final OauthLoginCodeService oauthLoginCodeService;
-    
+
     @Value("${oauth.google.success-redirect-url}")
     private String successRedirectUrl;
 
@@ -37,27 +37,25 @@ public class OauthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     ) throws IOException, ServletException {
 
         /*
-         * 1. OauthUserService에서 반환한 principal을 가져옵니다.
+         * OauthUserService에서 반환한 principal을 가져옵니다.
          */
         OauthUserDto principal = (OauthUserDto) authentication.getPrincipal();
         User user = principal.getUser();
 
         /*
-         * 2. 기존 JWT 발급 로직을 재사용합니다.
+         * 기존 JWT 발급 로직을 재사용합니다.
          */
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
 
         /*
-         * 3. 기존 Redis Refresh Token 저장 로직을 재사용합니다.
-         * 이 값은 refreshToken rotation/reissue/logout 흐름에서 사용됩니다.
+         * Refresh Token은 기존 Redis 저장 구조를 유지합니다.
          */
         refreshTokenService.saveRefreshToken(user.getUserId(), refreshToken);
 
         /*
-         * 4. 실제 토큰은 URL에 싣지 않고 Redis에 1회용 code로 임시 저장합니다.
+         * 실제 토큰은 URL에 싣지 않고 Redis에 1회용 code로 임시 저장합니다.
          */
-        
         boolean profileRequired = user.isProfileIncomplete();
 
         String code = oauthLoginCodeService.saveToken(
@@ -65,10 +63,9 @@ public class OauthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
                 refreshToken,
                 profileRequired
         );
-        
+
         /*
-         * 5. 프론트 성공 페이지에는 실제 토큰 대신 1회용 code만 전달합니다.
-         * 
+         * 프론트에는 실제 토큰 대신 1회용 code만 전달합니다.
          */
         String redirectUrl = UriComponentsBuilder
                 .fromUriString(successRedirectUrl)
@@ -77,9 +74,6 @@ public class OauthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
                 .build()
                 .toUriString();
 
-        /*
-         * 6. OAuth 인증 과정에서 사용한 임시 인증 정보를 정리합니다.
-         */
         clearAuthenticationAttributes(request);
 
         getRedirectStrategy().sendRedirect(request, response, redirectUrl);

--- a/src/main/java/kr/co/mapspring/user/oauth/service/OauthLoginCodeService.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/service/OauthLoginCodeService.java
@@ -26,7 +26,7 @@ public class OauthLoginCodeService {
     private final ObjectMapper objectMapper;
 
     /*
-     * OAuth 로그인 성공 후 accessToken/refreshToken을 직접 URL에 싣지 않기 위해
+     * OAuth 로그인 성공 후 실제 토큰을 URL에 직접 싣지 않기 위해
      * Redis에 1회용 code 기준으로 임시 저장합니다.
      */
     public String saveToken(
@@ -37,14 +37,14 @@ public class OauthLoginCodeService {
         String code = UUID.randomUUID().toString();
         String key = OAUTH_LOGIN_CODE_PREFIX + code;
 
-        OauthLoginDto.ResponseToken response = OauthLoginDto.ResponseToken.of(
+        OauthLoginDto.TokenResult tokenResult = OauthLoginDto.TokenResult.of(
                 accessToken,
                 refreshToken,
                 profileRequired
         );
 
         try {
-            String value = objectMapper.writeValueAsString(response);
+            String value = objectMapper.writeValueAsString(tokenResult);
 
             stringRedisTemplate.opsForValue()
                     .set(key, value, OAUTH_LOGIN_CODE_TTL);
@@ -60,18 +60,21 @@ public class OauthLoginCodeService {
      * 조회 후 즉시 삭제하여 1회용으로만 사용되게 합니다.
      */
     @Transactional
-    public OauthLoginDto.ResponseToken consumeToken(String code) {
+    public OauthLoginDto.TokenResult consumeToken(String code) {
         String key = OAUTH_LOGIN_CODE_PREFIX + code;
         String value = stringRedisTemplate.opsForValue().get(key);
 
         if (value == null) {
-            throw new CustomException(ErrorCode.BAD_REQUEST, "유효하지 않거나 만료된 OAuth 로그인 코드입니다.");
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
+        /*
+         * code 재사용을 막기 위해 조회 직후 삭제합니다.
+         */
         stringRedisTemplate.delete(key);
 
         try {
-            return objectMapper.readValue(value, OauthLoginDto.ResponseToken.class);
+            return objectMapper.readValue(value, OauthLoginDto.TokenResult.class);
         } catch (JsonProcessingException e) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/kr/co/mapspring/user/service/impl/LoginServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/LoginServiceImpl.java
@@ -41,6 +41,11 @@ public class LoginServiceImpl implements LoginService {
     public ResponseLogin login(RequestLogin request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        
+        // 비밀번호 null 방지 방어로직 
+        if (user.getPasswordHash() == null) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
@@ -50,10 +55,7 @@ public class LoginServiceImpl implements LoginService {
             throw new CustomException(ErrorCode.INACTIVE_USER);
         }
         
-        // 비밀번호 null 방지 방어로직 
-        if (user.getPasswordHash() == null) {
-            throw new CustomException(ErrorCode.INVALID_PASSWORD);
-        }
+
 
         String accessToken = jwtTokenProvider.createAccessToken(user);
 

--- a/src/main/java/kr/co/mapspring/user/service/impl/LoginServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/LoginServiceImpl.java
@@ -41,8 +41,11 @@ public class LoginServiceImpl implements LoginService {
     public ResponseLogin login(RequestLogin request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        
-        // 비밀번호 null 방지 방어로직 
+
+        /*
+         * 소셜 회원은 passwordHash가 null일 수 있습니다.
+         * passwordEncoder.matches(...)보다 먼저 검사해야 합니다.
+         */
         if (user.getPasswordHash() == null) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
@@ -54,13 +57,15 @@ public class LoginServiceImpl implements LoginService {
         if (!user.isActive()) {
             throw new CustomException(ErrorCode.INACTIVE_USER);
         }
-        
-
 
         String accessToken = jwtTokenProvider.createAccessToken(user);
 
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
 
+        /*
+         * Refresh Token은 기존처럼 Redis에 저장합니다.
+         * 다만 클라이언트에는 body가 아니라 HttpOnly Cookie로 내려갑니다.
+         */
         refreshTokenService.saveRefreshToken(user.getUserId(), refreshToken);
 
         return LoginDto.ResponseLogin.from(user, accessToken, refreshToken);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,40 +6,50 @@ spring.datasource.password=${DB_PASSWORD}
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# 테스트 끝나고는 update로 변경
+# íì¤í¸ ëëê³ ë updateë¡ ë³ê²½
 spring.jpa.hibernate.ddl-auto=create
 
-# data.sql 항상 실행
+# data.sql í­ì ì¤í
 spring.sql.init.mode=always
 
-# JPA 테이블 생성 후 data.sql 실행되도록 순서 보장
+# JPA íì´ë¸ ìì± í data.sql ì¤íëëë¡ ìì ë³´ì¥
 spring.jpa.defer-datasource-initialization=true
 
 spring.jpa.show-sql=true
 
-# JWT 설정
-# 실제 값은 환경변수 JWT_SECRET에서 가져온다.
-# HS256 서명용이므로 최소 32자 이상으로 설정하는 것을 권장한다.
+# JWT ì¤ì 
+# ì¤ì  ê°ì íê²½ë³ì JWT_SECRETìì ê°ì ¸ì¨ë¤.
+# HS256 ìëªì©ì´ë¯ë¡ ìµì 32ì ì´ìì¼ë¡ ì¤ì íë ê²ì ê¶ì¥íë¤.
 jwt.secret=${JWT_SECRET}
 
-# Access Token 만료 시간
-# 3600000ms = 1시간
+# Access Token ë§ë£ ìê°
+# 3600000ms = 1ìê°
 jwt.access-token-expiration=${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
 
-# Redis 설정
+# Redis ì¤ì 
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
 
-# Refresh Token 만료 시간
-# 604800000ms = 7일
+# Refresh Token ë§ë£ ìê°
+# 604800000ms = 7ì¼
 jwt.refresh-token-expiration=${JWT_REFRESH_TOKEN_EXPIRATION:604800000}
 
 # Google OAuth
-# 실제 값은 환경변수에서 가져온다.
+# ì¤ì  ê°ì íê²½ë³ììì ê°ì ¸ì¨ë¤.
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
 spring.security.oauth2.client.registration.google.scope=profile,email
 
-# OAuth 로그인 성공/실패 후 프론트 redirect 주소
+# OAuth ë¡ê·¸ì¸ ì±ê³µ/ì¤í¨ í íë¡ í¸ redirect ì£¼ì
 oauth.google.success-redirect-url=${OAUTH_GOOGLE_SUCCESS_REDIRECT_URL:http://localhost:5173/oauth/success}
 oauth.google.failure-redirect-url=${OAUTH_GOOGLE_FAILURE_REDIRECT_URL:http://localhost:5173/oauth/failure}
+
+
+# Auth Cookie
+# 로컬 개발환경 기준 설정
+auth.cookie.refresh-token-name=refreshToken
+auth.cookie.path=/
+auth.cookie.domain=
+auth.cookie.http-only=true
+auth.cookie.secure=false
+auth.cookie.same-site=Lax


### PR DESCRIPTION
## 작업내용

-  기존에 응답 body 또는 OAuth redirect URL을 통해 전달되던 Refresh Token을 HttpOnly Cookie 방식으로 전환
- 로그인 성공 시 Access Token은 기존처럼 응답 body로 반환하고, Refresh Token은 `Set-Cookie` 헤더를 통해 HttpOnly Cookie로 저장되도록 수정
- 토큰 재발급과 로그아웃 요청은 더 이상 request body로 Refresh Token을 받지 않고, 요청 Cookie에서 Refresh Token을 추출해 처리하도록 변경
- Google OAuth 로그인 흐름에서도 실제 토큰을 URL에 직접 싣지 않고, 1회용 code 교환 후 Refresh Token은 HttpOnly Cookie로 설정되도록 정리
- Refresh Token이 JSON 응답에 노출되지 않도록 관련 Response DTO의 refreshToken 필드에 `@JsonIgnore`를 적용


## 변경사항
(예시) - UserController.java 추가


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
(예시) - [v] 로컬 테스트 완료
(예시) - swagger 화면 이미지.jpg(.png)


## 참고사항
(예시) swagger 문서화 어노테이션을 사용하였다.

