### PR TITLE
fix(learning): 학습 목표 삭제 시 delete 호출 누락 수정

### DIFF
--- a/src/main/java/kr/co/mapspring/chat/controller/ChatController.java
+++ b/src/main/java/kr/co/mapspring/chat/controller/ChatController.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 @RequiredArgsConstructor
-public class ChatController implements ChatControllerDocs {
+public class  ChatController implements ChatControllerDocs {
 
     private final ChatService chatService;
     private final SimpMessagingTemplate messagingTemplate;

--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -87,7 +87,7 @@ public enum ErrorCode {
 	SCENARIO_IN_USE(HttpStatus.CONFLICT, "참조 중인 시나리오입니다."),
 	
 	// User MissionSession
-	MISSION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 미션 세션입니다.");
+	MISSION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 미션 세션입니다."),
 	// FastAPI 연동
 	FASTAPI_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FastAPI 연동 중 오류가 발생했습니다.");
 

--- a/src/main/java/kr/co/mapspring/learning/service/impl/AdminLearningServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/learning/service/impl/AdminLearningServiceImpl.java
@@ -83,6 +83,6 @@ public class AdminLearningServiceImpl implements AdminLearningService {
         GoalMaster goalMaster = goalMasterRepository.findById(goalMasterId)
                 .orElseThrow(GoalMasterNotFoundException::new);
 
-        goalMaster.updateActive(false);
+        goalMasterRepository.delete(goalMaster);
     }
 }


### PR DESCRIPTION
## 작업내용
- 학습 목표 삭제 기능 구현 수


## 변경사항
- deleteGoal()에서 비활성화 처리 → 실제 삭제 처리로 변경
- goalMasterRepository.delete(goalMaster) 추가

## 변경 이유
- 기존 deleteGoal() 메서드가 updateActive(false)로 동작하여
  "삭제"와 "비활성화"의 역할이 혼재되어 있었음
- updateGoalActive()에서 이미 활성/비활성 기능을 담당하고 있어
  deleteGoal()은 실제 삭제로 분리

## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [x] AdminLearningServiceTest 전체 통과 확인
- [x] deleteGoal() 테스트에서 delete() 호출 검증 통과
<img width="434" height="276" alt="image" src="https://github.com/user-attachments/assets/edc1bc1d-9f7a-4554-81d4-e38c1a9818ff" />


## 참고사항
- 활성/비활성은 updateGoalActive()
- 실제 삭제는 deleteGoal()로 역할 분리

