### PR TITLE
fix(social): 관리자 신고 상태 변경 DTO 바인딩 오류 수정

### DIFF
--- a/src/main/java/kr/co/mapspring/social/dto/AdminSocialDto.java
+++ b/src/main/java/kr/co/mapspring/social/dto/AdminSocialDto.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -58,6 +59,7 @@ public class AdminSocialDto {
     }
 
     @Getter
+    @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(description = "관리자 신고 상태 변경 요청 DTO")


### PR DESCRIPTION
## 작업내용
- 관리자 신고 상태 변경 요청 DTO 수정
- 관리자 신고 상태 변경 API 바인딩 오류 해결


## 변경사항
- AdminSocialDto.RequestUpdateReportStatus DTO에 @Setter 추가
- JSON RequestBody → DTO 매핑 정상 동작하도록 수정


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [x] Swagger PATCH 요청 정상 동작 확인
- [x] 관리자 신고 상태 변경 API 정상 동작 확인
- [x] 프론트 관리자 친구 관리 페이지 연동 확인


## 참고사항
- 기존에는 Request DTO에 Setter가 없어 JSON 바인딩이 실패하던 문제 수정

