### PR TITLE
fix(global): 학습 목표 삭제 예외 메시지 처리 추가

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/mapspring/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import kr.co.mapspring.global.exception.learning.GoalAlreadySelectedException;
 import kr.co.mapspring.global.exception.learning.GoalMasterNotFoundException;
 import kr.co.mapspring.global.exception.learning.GoalSelectionLimitExceededException;
 import kr.co.mapspring.global.exception.learning.UserGoalNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
@@ -32,7 +33,6 @@ public class GlobalExceptionHandler {
                 .body(ApiResponseDTO.fail(errorCode.getStatus(), e.getMessage()));
     }
 
-    // Learning 목표 관련 예외 처리
     @ExceptionHandler({
             GoalSelectionLimitExceededException.class
     })
@@ -56,14 +56,14 @@ public class GlobalExceptionHandler {
                 ));
     }
 
-    @ExceptionHandler(GoalAlreadySelectedException.class)
-    public ResponseEntity<ApiResponseDTO<Object>> handleGoalAlreadySelectedException(
-            GoalAlreadySelectedException e
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponseDTO<Object>> handleDataIntegrityViolationException(
+            DataIntegrityViolationException e
     ) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(ApiResponseDTO.fail(
                         HttpStatus.CONFLICT,
-                        e.getMessage()
+                        "사용 중인 학습 목표는 삭제할 수 없습니다. 비활성화를 이용해주세요."
                 ));
     }
 


### PR DESCRIPTION
## 작업내용
- 학습 목표 삭제 시 발생하던 서버 내부 오류 메시지 처리 개선
- 사용 중인 학습 목표 삭제 요청에 대한 예외 처리 추가


## 변경사항
- DataIntegrityViolationException 예외 처리 추가
- 사용 중인 학습 목표 삭제 시 500 대신 409(CONFLICT) 응답 반환
- 사용자에게 비활성화 사용을 안내하는 메시지로 변경

## 수정 전
- "서버 내부 오류가 발생했습니다."

## 수정 후
- "사용 중인 학습 목표는 삭제할 수 없습니다. 비활성화를 이용해주세요."


## 테스트 결과
- [x] 사용 중이지 않은 목표 삭제 정상 동작 확인
- [x] 사용 중인 목표 삭제 시 안내 메시지 정상 출력 확인
- [x] 서버 내부 오류(500) 대신 CONFLICT(409) 응답 반환 확인


## 참고사항
- 기존에 존재하던 목표 삭제 시 서버 내부 오류 메시지 출력 문제 수정

