### PR TITLE
feat(user) : 소셜 회원가입 중복 가입 방지 로직 추가 및 이슈 해결(주소)

### DIFF
--- a/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/SignUpDto.java
@@ -41,9 +41,9 @@ public class SignUpDto {
     	
     	@NotBlank(message = "주소를 입력해주세요.")
     	@Pattern(
-    	    regexp = "^[가-힣\\s]+$", 
-    	    message = "주소는 한글과 띄어쓰기만 입력 가능합니다."
-    	)
+    		    regexp = "^[가-힣a-zA-Z0-9\\s\\-\\.\\,]+$",
+    		    message = "주소 형식이 올바르지 않습니다."
+    		)
         @Schema(description = "주소", example = "서울시 강남구")
         private String address;
     	

--- a/src/main/java/kr/co/mapspring/user/dto/UserDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/UserDto.java
@@ -63,9 +63,9 @@ public class UserDto {
 
     	@NotBlank(message = "주소를 입력해주세요.")
     	@Pattern(
-    	    regexp = "^[가-힣\\s]+$", 
-    	    message = "주소는 한글과 띄어쓰기만 입력 가능합니다."
-    	)
+    		    regexp = "^[가-힣a-zA-Z0-9\\s\\-\\.\\,]+$",
+    		    message = "주소 형식이 올바르지 않습니다."
+    		)
         @Schema(description = "주소", example = "서울시 강남구")
         private String address;
 

--- a/src/main/java/kr/co/mapspring/user/oauth/controller/OauthController.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/controller/OauthController.java
@@ -36,6 +36,8 @@ public class OauthController implements OauthControllerDocs {
         // ✅ 로그 추가 - 여기서 null이면 쿠키 내용이 비어서 세팅 안 됨
         System.out.println("=== OAuth Cookie Debug ===");
         System.out.println("refreshToken = " + tokenResult.getRefreshToken());
+        System.out.println("isNewUser = " + tokenResult.getIsNewUser());  // ✅ 추가
+        System.out.println("profileRequired = " + tokenResult.getProfileRequired());  // ✅ 추가
 
         String cookieValue = authCookieService
                 .createRefreshTokenCookie(tokenResult.getRefreshToken())

--- a/src/main/java/kr/co/mapspring/user/oauth/dto/OauthLoginDto.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/dto/OauthLoginDto.java
@@ -49,6 +49,7 @@ public class OauthLoginDto {
             return ResponseToken.builder()
                     .accessToken(tokenResult.getAccessToken())
                     .profileRequired(tokenResult.getProfileRequired())
+                    .isNewUser(tokenResult.getIsNewUser())
                     .build();
         }
     }

--- a/src/main/java/kr/co/mapspring/user/oauth/dto/OauthLoginDto.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/dto/OauthLoginDto.java
@@ -42,6 +42,8 @@ public class OauthLoginDto {
          */
         @Schema(description = "추가 프로필 입력 필요 여부", example = "true")
         private Boolean profileRequired;
+        
+        private Boolean isNewUser;
 
         public static ResponseToken from(TokenResult tokenResult) {
             return ResponseToken.builder()
@@ -66,16 +68,20 @@ public class OauthLoginDto {
         private String refreshToken;
 
         private Boolean profileRequired;
+        
+        private Boolean isNewUser;
 
         public static TokenResult of(
                 String accessToken,
                 String refreshToken,
-                Boolean profileRequired
+                Boolean profileRequired,
+                Boolean isNewUser
         ) {
             return TokenResult.builder()
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)
                     .profileRequired(profileRequired)
+                    .isNewUser(isNewUser)
                     .build();
         }
     }

--- a/src/main/java/kr/co/mapspring/user/oauth/dto/OauthUserDto.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/dto/OauthUserDto.java
@@ -36,6 +36,11 @@ public class OauthUserDto implements OAuth2User {
      * Spring Security에서 OAuth 사용자 식별자로 사용하는 값입니다.
      * 우리 서비스 기준에서는 userId를 사용합니다.
      */
+    
+    private final boolean newUser;
+
+    
+    
     @Override
     public String getName() {
         return String.valueOf(user.getUserId());

--- a/src/main/java/kr/co/mapspring/user/oauth/handler/OauthLoginSuccessHandler.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/handler/OauthLoginSuccessHandler.java
@@ -57,11 +57,13 @@ public class OauthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
          * 실제 토큰은 URL에 싣지 않고 Redis에 1회용 code로 임시 저장합니다.
          */
         boolean profileRequired = user.isProfileIncomplete();
+        boolean isNewUser = principal.isNewUser();
 
         String code = oauthLoginCodeService.saveToken(
                 accessToken,
                 refreshToken,
-                profileRequired
+                profileRequired,
+                isNewUser
         );
 
         /*

--- a/src/main/java/kr/co/mapspring/user/oauth/service/OauthLoginCodeService.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/service/OauthLoginCodeService.java
@@ -32,7 +32,8 @@ public class OauthLoginCodeService {
     public String saveToken(
             String accessToken,
             String refreshToken,
-            boolean profileRequired
+            boolean profileRequired,
+            boolean isNewUser
     ) {
         String code = UUID.randomUUID().toString();
         String key = OAUTH_LOGIN_CODE_PREFIX + code;
@@ -40,7 +41,8 @@ public class OauthLoginCodeService {
         OauthLoginDto.TokenResult tokenResult = OauthLoginDto.TokenResult.of(
                 accessToken,
                 refreshToken,
-                profileRequired
+                profileRequired,
+                isNewUser
         );
 
         try {

--- a/src/main/java/kr/co/mapspring/user/oauth/service/OauthUserService.java
+++ b/src/main/java/kr/co/mapspring/user/oauth/service/OauthUserService.java
@@ -89,7 +89,9 @@ public class OauthUserService implements OAuth2UserService<OAuth2UserRequest, OA
         /*
          * 7. Spring Security 인증 객체에 들어갈 DTO를 반환합니다.
          */
-        return new OauthUserDto(user, attributes, authorities);
+        
+        boolean isNewUser = user.isProfileIncomplete();
+        return new OauthUserDto(user, attributes, authorities,isNewUser);
     }
 
     private User findOrCreateUser(


### PR DESCRIPTION
## 작업내용

- 소셜 중복 가입 방지를 위한 isNewUser 판별 로직 추가
- 회원가입 주소 정규식 수정 (숫자/특수문자 허용)


## 변경사항
- `OauthUserDto.java` - `isNewUser` 필드 추가
- `OauthUserService.java` - `isNewUser` 값 전달
- `OauthLoginDto.java` - `TokenResult`, `ResponseToken`에 `isNewUser` 추가
- `OauthLoginCodeService.java` - `saveToken`에 `isNewUser` 파라미터 추가
- `OauthLoginSuccessHandler.java` - `isNewUser` 전달
- `SignUpDto.java` - 주소 정규식 수정 (한글 + 숫자 + 특수문자 허용)

## 테스트 결과_캡쳐 이미지 (.jpg/.png)


## 참고사항


