### PR TITLE
fix(admin-ranking): 관리자 랭킹 사용자 이름 조회 기능 수정

### DIFF
--- a/src/main/java/kr/co/mapspring/ranking/dto/RankingDto.java
+++ b/src/main/java/kr/co/mapspring/ranking/dto/RankingDto.java
@@ -18,20 +18,25 @@ public class RankingDto {
         @Schema(description = "사용자 ID", example = "3")
         private Long userId;
 
+        @Schema(description = "사용자 이름", example = "홍길동")
+        private String userName;
+
         @Schema(description = "총 점수", example = "950")
         private Long totalScore;
 
         @Builder
-        public ResponseRanking(int rank, Long userId, Long totalScore) {
+        public ResponseRanking(int rank, Long userId, String userName, Long totalScore) {
             this.rank = rank;
             this.userId = userId;
+            this.userName = userName;
             this.totalScore = totalScore;
         }
 
-        public static ResponseRanking from(int rank, Long userId, Long totalScore) {
+        public static ResponseRanking from(int rank, Long userId, String userName, Long totalScore) {
             return ResponseRanking.builder()
                     .rank(rank)
                     .userId(userId)
+                    .userName(userName)
                     .totalScore(totalScore)
                     .build();
         }

--- a/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
+++ b/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
@@ -10,18 +10,18 @@ import java.util.List;
 public interface RankingRepository extends JpaRepository<StudyScore, Long> {
 
     @Query("""
-           SELECT ss.studyLog.user.userId, SUM(ss.totalScore)
+           SELECT ss.studyLog.user.userId, ss.studyLog.user.name, SUM(ss.totalScore)
            FROM StudyScore ss
-           GROUP BY ss.studyLog.user.userId
+           GROUP BY ss.studyLog.user.userId, ss.studyLog.user.name
            ORDER BY SUM(ss.totalScore) DESC    
            """)
     List<Object[]> findRanking();
 
     @Query("""
-           SELECT ss.studyLog.user.userId, SUM(ss.totalScore)
+           SELECT ss.studyLog.user.userId, ss.studyLog.user.name, SUM(ss.totalScore)
            FROM StudyScore ss
            WHERE ss.studyLog.user.userId IN :friendIds
-           GROUP BY ss.studyLog.user.userId
+           GROUP BY ss.studyLog.user.userId, ss.studyLog.user.name
            ORDER BY SUM(ss.totalScore) DESC
            """)
     List<Object[]> findFriendRanking(List<Long> friendIds);
@@ -41,10 +41,10 @@ public interface RankingRepository extends JpaRepository<StudyScore, Long> {
     Double findFriendAverageScore(List<Long> friendIds);
 
     @Query("""
-       SELECT ss.studyLog.user.userId, SUM(ss.totalScore)
+       SELECT ss.studyLog.user.userId, ss.studyLog.user.name, SUM(ss.totalScore)
        FROM StudyScore ss
        WHERE ss.studyLog.learningSession.endTime >= :startDateTime
-       GROUP BY ss.studyLog.user.userId
+       GROUP BY ss.studyLog.user.userId, ss.studyLog.user.name
        ORDER BY SUM(ss.totalScore) DESC
        """)
     List<Object[]> findWeeklyRanking(LocalDateTime startDateTime);

--- a/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/ranking/service/impl/RankingServiceImpl.java
@@ -31,20 +31,7 @@ public class RankingServiceImpl implements RankingService {
 
         List<Object[]> rankingResult = rankingRepository.findRanking();
 
-        return IntStream.range(0, rankingResult.size())
-                .mapToObj(index -> {
-                    Object[] row = rankingResult.get(index);
-
-                    Long userId = (Long) row[0];
-                    Long totalScore = (Long) row[1];
-
-                    return RankingDto.ResponseRanking.from(
-                            index + 1,
-                            userId,
-                            totalScore
-                    );
-                })
-                .toList();
+        return convertToRankingResponse(rankingResult);
     }
 
     @Override
@@ -136,11 +123,13 @@ public class RankingServiceImpl implements RankingService {
                     Object[] row = rankingResult.get(index);
 
                     Long userId = (Long) row[0];
-                    Long totalScore = (Long) row[1];
+                    String userName = (String) row[1];
+                    Long totalScore = (Long) row[2];
 
                     return RankingDto.ResponseRanking.from(
                             index + 1,
                             userId,
+                            userName,
                             totalScore
                     );
                 })

--- a/src/test/java/kr/co/mapspring/ranking/service/AdminRankingServiceTest.java
+++ b/src/test/java/kr/co/mapspring/ranking/service/AdminRankingServiceTest.java
@@ -29,10 +29,10 @@ public class AdminRankingServiceTest {
     void 관리자는_전체_랭킹을_조회한다() {
 
         RankingDto.ResponseRanking ranking1 =
-                RankingDto.ResponseRanking.from(1, 1L, 300L);
+                RankingDto.ResponseRanking.from(1, 1L, "AI코칭테스트", 300L);
 
         RankingDto.ResponseRanking ranking2 =
-                RankingDto.ResponseRanking.from(2, 2L, 250L);
+                RankingDto.ResponseRanking.from(2, 2L, "이민수", 250L);
 
         given(rankingService.getRankings())
                 .willReturn(List.of(ranking1, ranking2));
@@ -45,6 +45,7 @@ public class AdminRankingServiceTest {
         assertEquals(2, result.size());
         assertEquals(1, result.get(0).getRank());
         assertEquals(1L, result.get(0).getUserId());
+        assertEquals("AI코칭테스트", result.get(0).getUserName());
         assertEquals(300L, result.get(0).getTotalScore());
     }
 
@@ -53,10 +54,10 @@ public class AdminRankingServiceTest {
     void 관리자는_주간_랭킹을_조회한다() {
 
         RankingDto.ResponseRanking ranking1 =
-                RankingDto.ResponseRanking.from(1, 1L, 150L);
+                RankingDto.ResponseRanking.from(1, 1L, "AI코칭테스트", 150L);
 
         RankingDto.ResponseRanking ranking2 =
-                RankingDto.ResponseRanking.from(2, 2L, 100L);
+                RankingDto.ResponseRanking.from(2, 2L, "이민수", 100L);
 
         given(rankingService.getWeeklyRankings())
                 .willReturn(List.of(ranking1, ranking2));
@@ -68,6 +69,7 @@ public class AdminRankingServiceTest {
 
         assertEquals(2, result.size());
         assertEquals(1, result.get(0).getRank());
+        assertEquals("AI코칭테스트", result.get(0).getUserName());
         assertEquals(150L, result.get(0).getTotalScore());
     }
 


### PR DESCRIPTION
## 작업내용
- 관리자 전체 랭킹 조회 시 사용자 이름 포함 기능 구현
- 주간 랭킹 / 친구 랭킹 사용자 이름 조회 기능 수정
- Ranking DTO 구조 수정


## 변경사항
- RankingDto.ResponseRanking에 userName 필드 추가
- RankingRepository JPQL에 user.name 조회 추가
- GROUP BY 조건에 user.name 추가
- RankingServiceImpl 응답 매핑 수정
- SUM 결과 타입 캐스팅 안정성 개선
- 관리자 랭킹 테스트 코드 수정


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [x] 전체 랭킹 조회 정상 동작 확인
- [x] 주간 랭킹 조회 정상 동작 확인
- [x] 사용자 이름 표시 정상 동작 확인
- [x] 테스트 코드 통과 확인
<img width="361" height="337" alt="image" src="https://github.com/user-attachments/assets/be3c02e7-9c6b-403c-81f6-3fcc86ea5623" />



## 참고사항
- 관리자 랭킹 화면에서 USER 1 형식 대신 실제 사용자 이름 표시

