### PR TITLE
fix(learning): 학습 목표 조회 시 목표 정보 함께 조회

### DIFF
--- a/src/main/java/kr/co/mapspring/learning/repository/UserGoalRepository.java
+++ b/src/main/java/kr/co/mapspring/learning/repository/UserGoalRepository.java
@@ -3,6 +3,8 @@ package kr.co.mapspring.learning.repository;
 import kr.co.mapspring.learning.entity.UserGoal;
 import kr.co.mapspring.learning.enums.UserGoalStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,4 +16,15 @@ public interface UserGoalRepository extends JpaRepository<UserGoal, Long> {
 
     List<UserGoal> findAllByUser_UserIdAndStatus(Long userId, UserGoalStatus status);
 
+    @Query("""
+           SELECT ug
+           FROM UserGoal ug
+           JOIN FETCH ug.goalMaster
+           WHERE ug.user.userId = :userId
+             AND ug.status = :status
+           """)
+    List<UserGoal> findByUserIdAndStatusWithGoalMaster(
+            @Param("userId") Long userId,
+            @Param("status") UserGoalStatus status
+    );
 }

--- a/src/main/java/kr/co/mapspring/learning/service/impl/LearningGoalServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/learning/service/impl/LearningGoalServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class LearningGoalServiceImpl implements LearningGoalService {
+
     private static final int MAX_GOAL_COUNT = 3;
 
     private final GoalMasterRepository goalMasterRepository;
@@ -43,13 +44,20 @@ public class LearningGoalServiceImpl implements LearningGoalService {
                 .orElseThrow(GoalMasterNotFoundException::new);
 
         boolean alreadySelected =
-                userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(userId, goalMasterId, UserGoalStatus.ACTIVE);
+                userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(
+                        userId,
+                        goalMasterId,
+                        UserGoalStatus.ACTIVE
+                );
 
         if (alreadySelected) {
             throw new GoalAlreadySelectedException();
         }
 
-        int selectedCount = userGoalRepository.countByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        int selectedCount = userGoalRepository.countByUser_UserIdAndStatus(
+                userId,
+                UserGoalStatus.ACTIVE
+        );
 
         if (selectedCount >= MAX_GOAL_COUNT) {
             throw new GoalSelectionLimitExceededException();
@@ -74,22 +82,47 @@ public class LearningGoalServiceImpl implements LearningGoalService {
 
     @Override
     public List<UserGoal> getActiveGoals(Long userId) {
-        return userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        return userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        );
     }
 
-    private LocalDate calculateEndDate(LocalDate startDate, GoalMaster goalMaster) {
-        return switch (goalMaster.getPeriodType()) {
-            case DAILY -> startDate;
-            case WEEKLY -> startDate.plusWeeks(1);
-            case MONTHLY -> startDate.plusMonths(1);
-            case NONE -> null;
-        };
+    @Override
+    public List<UserGoal> getCompletedGoals(Long userId) {
+        return userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.COMPLETED
+        );
+    }
+
+    @Override
+    public List<GoalMaster> getAvailableGoals(Long userId) {
+        List<GoalMaster> activeGoalMasters = goalMasterRepository.findAllByIsActiveTrue();
+
+        List<UserGoal> activeUserGoals =
+                userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                        userId,
+                        UserGoalStatus.ACTIVE
+                );
+
+        Set<Long> selectedGoalIds = activeUserGoals.stream()
+                .map(userGoal -> userGoal.getGoalMaster().getGoalMasterId())
+                .collect(Collectors.toSet());
+
+        return activeGoalMasters.stream()
+                .filter(goalMaster -> !selectedGoalIds.contains(goalMaster.getGoalMasterId()))
+                .toList();
     }
 
     @Override
     @Transactional
     public void updateGoalProgress(Long userId, GoalType goalType, Integer amount) {
-        List<UserGoal> activeGoals = userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        List<UserGoal> activeGoals =
+                userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                        userId,
+                        UserGoalStatus.ACTIVE
+                );
 
         for (UserGoal userGoal : activeGoals) {
             if (userGoal.getGoalMaster().getGoalType() != goalType) {
@@ -105,22 +138,12 @@ public class LearningGoalServiceImpl implements LearningGoalService {
         }
     }
 
-    @Override
-    public List<UserGoal> getCompletedGoals(Long userId) {
-        return userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.COMPLETED);
-    }
-
-    @Override
-    public List<GoalMaster> getAvailableGoals(Long userId) {
-        List<GoalMaster> activeGoalMasters = goalMasterRepository.findAllByIsActiveTrue();
-        List<UserGoal> activeUserGoals = userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
-
-        Set<Long> selectedGoalIds = activeUserGoals.stream()
-                .map(userGoal -> userGoal.getGoalMaster().getGoalMasterId())
-                .collect(Collectors.toSet());
-
-        return activeGoalMasters.stream()
-                .filter(goalMaster -> !selectedGoalIds.contains(goalMaster.getGoalMasterId()))
-                .toList();
+    private LocalDate calculateEndDate(LocalDate startDate, GoalMaster goalMaster) {
+        return switch (goalMaster.getPeriodType()) {
+            case DAILY -> startDate;
+            case WEEKLY -> startDate.plusWeeks(1);
+            case MONTHLY -> startDate.plusMonths(1);
+            case NONE -> null;
+        };
     }
 }

--- a/src/test/java/kr/co/mapspring/learning/service/LearningGoalServiceTest.java
+++ b/src/test/java/kr/co/mapspring/learning/service/LearningGoalServiceTest.java
@@ -92,8 +92,11 @@ class LearningGoalServiceTest {
         given(goalMasterRepository.findById(goalMasterId))
                 .willReturn(Optional.of(goalMaster));
 
-        given(userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(userId, goalMasterId, UserGoalStatus.ACTIVE))
-                .willReturn(false);
+        given(userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(
+                userId,
+                goalMasterId,
+                UserGoalStatus.ACTIVE
+        )).willReturn(false);
 
         given(userGoalRepository.countByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE))
                 .willReturn(2);
@@ -102,7 +105,11 @@ class LearningGoalServiceTest {
 
         verify(userRepository).findById(userId);
         verify(goalMasterRepository).findById(goalMasterId);
-        verify(userGoalRepository).existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(userId, goalMasterId, UserGoalStatus.ACTIVE);
+        verify(userGoalRepository).existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(
+                userId,
+                goalMasterId,
+                UserGoalStatus.ACTIVE
+        );
         verify(userGoalRepository).countByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
 
         ArgumentCaptor<UserGoal> captor = ArgumentCaptor.forClass(UserGoal.class);
@@ -127,12 +134,18 @@ class LearningGoalServiceTest {
         given(goalMasterRepository.findById(goalMasterId))
                 .willReturn(Optional.empty());
 
-        assertThrows(GoalMasterNotFoundException.class,
-                () -> learningGoalService.selectGoal(userId, goalMasterId));
+        assertThrows(
+                GoalMasterNotFoundException.class,
+                () -> learningGoalService.selectGoal(userId, goalMasterId)
+        );
 
         verify(userRepository).findById(userId);
         verify(goalMasterRepository).findById(goalMasterId);
-        verify(userGoalRepository, never()).existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(any(), any(), any());
+        verify(userGoalRepository, never()).existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(
+                any(),
+                any(),
+                any()
+        );
         verify(userGoalRepository, never()).countByUser_UserIdAndStatus(any(), any());
         verify(userGoalRepository, never()).save(any(UserGoal.class));
     }
@@ -146,15 +159,24 @@ class LearningGoalServiceTest {
         given(goalMasterRepository.findById(goalMasterId))
                 .willReturn(Optional.of(goalMaster));
 
-        given(userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(userId, goalMasterId, UserGoalStatus.ACTIVE))
-                .willReturn(true);
+        given(userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(
+                userId,
+                goalMasterId,
+                UserGoalStatus.ACTIVE
+        )).willReturn(true);
 
-        assertThrows(GoalAlreadySelectedException.class,
-                () -> learningGoalService.selectGoal(userId, goalMasterId));
+        assertThrows(
+                GoalAlreadySelectedException.class,
+                () -> learningGoalService.selectGoal(userId, goalMasterId)
+        );
 
         verify(userRepository).findById(userId);
         verify(goalMasterRepository).findById(goalMasterId);
-        verify(userGoalRepository).existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(userId, goalMasterId, UserGoalStatus.ACTIVE);
+        verify(userGoalRepository).existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(
+                userId,
+                goalMasterId,
+                UserGoalStatus.ACTIVE
+        );
         verify(userGoalRepository, never()).countByUser_UserIdAndStatus(any(), any());
         verify(userGoalRepository, never()).save(any(UserGoal.class));
     }
@@ -168,18 +190,27 @@ class LearningGoalServiceTest {
         given(goalMasterRepository.findById(goalMasterId))
                 .willReturn(Optional.of(goalMaster));
 
-        given(userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(userId, goalMasterId, UserGoalStatus.ACTIVE))
-                .willReturn(false);
+        given(userGoalRepository.existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(
+                userId,
+                goalMasterId,
+                UserGoalStatus.ACTIVE
+        )).willReturn(false);
 
         given(userGoalRepository.countByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE))
                 .willReturn(3);
 
-        assertThrows(GoalSelectionLimitExceededException.class,
-                () -> learningGoalService.selectGoal(userId, goalMasterId));
+        assertThrows(
+                GoalSelectionLimitExceededException.class,
+                () -> learningGoalService.selectGoal(userId, goalMasterId)
+        );
 
         verify(userRepository).findById(userId);
         verify(goalMasterRepository).findById(goalMasterId);
-        verify(userGoalRepository).existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(userId, goalMasterId, UserGoalStatus.ACTIVE);
+        verify(userGoalRepository).existsByUser_UserIdAndGoalMaster_GoalMasterIdAndStatus(
+                userId,
+                goalMasterId,
+                UserGoalStatus.ACTIVE
+        );
         verify(userGoalRepository).countByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
         verify(userGoalRepository, never()).save(any(UserGoal.class));
     }
@@ -216,8 +247,10 @@ class LearningGoalServiceTest {
         given(userGoalRepository.findById(userGoalId))
                 .willReturn(Optional.empty());
 
-        assertThrows(UserGoalNotFoundException.class,
-                () -> learningGoalService.cancelGoal(userGoalId));
+        assertThrows(
+                UserGoalNotFoundException.class,
+                () -> learningGoalService.cancelGoal(userGoalId)
+        );
 
         verify(userGoalRepository).findById(userGoalId);
     }
@@ -245,12 +278,17 @@ class LearningGoalServiceTest {
                 LocalDate.now()
         );
 
-        given(userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE))
-                .willReturn(List.of(activeGoal1, activeGoal2));
+        given(userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        )).willReturn(List.of(activeGoal1, activeGoal2));
 
         List<UserGoal> result = learningGoalService.getActiveGoals(userId);
 
-        verify(userGoalRepository).findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        verify(userGoalRepository).findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        );
         assertEquals(2, result.size());
         assertEquals(UserGoalStatus.ACTIVE, result.get(0).getStatus());
         assertEquals(UserGoalStatus.ACTIVE, result.get(1).getStatus());
@@ -277,12 +315,17 @@ class LearningGoalServiceTest {
                 LocalDate.now()
         );
 
-        given(userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE))
-                .willReturn(List.of(userGoal));
+        given(userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        )).willReturn(List.of(userGoal));
 
         learningGoalService.updateGoalProgress(userId, GoalType.STUDY_COUNT, 1);
 
-        verify(userGoalRepository).findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        verify(userGoalRepository).findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        );
         assertEquals(2, userGoal.getCurrentValue());
         assertEquals(UserGoalStatus.ACTIVE, userGoal.getStatus());
     }
@@ -308,12 +351,17 @@ class LearningGoalServiceTest {
                 LocalDate.now()
         );
 
-        given(userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE))
-                .willReturn(List.of(userGoal));
+        given(userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        )).willReturn(List.of(userGoal));
 
         learningGoalService.updateGoalProgress(userId, GoalType.STUDY_COUNT, 1);
 
-        verify(userGoalRepository).findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        verify(userGoalRepository).findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        );
         assertEquals(3, userGoal.getCurrentValue());
         assertEquals(UserGoalStatus.COMPLETED, userGoal.getStatus());
     }
@@ -341,12 +389,17 @@ class LearningGoalServiceTest {
                 LocalDate.now()
         );
 
-        given(userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.COMPLETED))
-                .willReturn(List.of(completedGoal1, completedGoal2));
+        given(userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.COMPLETED
+        )).willReturn(List.of(completedGoal1, completedGoal2));
 
         List<UserGoal> result = learningGoalService.getCompletedGoals(userId);
 
-        verify(userGoalRepository).findAllByUser_UserIdAndStatus(userId, UserGoalStatus.COMPLETED);
+        verify(userGoalRepository).findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.COMPLETED
+        );
         assertEquals(2, result.size());
         assertEquals(UserGoalStatus.COMPLETED, result.get(0).getStatus());
         assertEquals(UserGoalStatus.COMPLETED, result.get(1).getStatus());
@@ -355,9 +408,29 @@ class LearningGoalServiceTest {
     @Test
     @DisplayName("사용자가 아직 선택하지 않은 목표 목록을 조회한다")
     void 사용자가_아직_선택하지_않은_목표_목록을_조회한다() {
-        GoalMaster goal1 = GoalMaster.of(1L, "하루 1회 학습", GoalPeriodType.DAILY, GoalType.STUDY_COUNT, 1);
-        GoalMaster goal2 = GoalMaster.of(2L, "하루 3회 학습", GoalPeriodType.DAILY, GoalType.STUDY_COUNT, 3);
-        GoalMaster goal3 = GoalMaster.of(3L, "주간 말하기 5회", GoalPeriodType.WEEKLY, GoalType.SPEAKING_COUNT, 5);
+        GoalMaster goal1 = GoalMaster.of(
+                1L,
+                "하루 1회 학습",
+                GoalPeriodType.DAILY,
+                GoalType.STUDY_COUNT,
+                1
+        );
+
+        GoalMaster goal2 = GoalMaster.of(
+                2L,
+                "하루 3회 학습",
+                GoalPeriodType.DAILY,
+                GoalType.STUDY_COUNT,
+                3
+        );
+
+        GoalMaster goal3 = GoalMaster.of(
+                3L,
+                "주간 말하기 5회",
+                GoalPeriodType.WEEKLY,
+                GoalType.SPEAKING_COUNT,
+                5
+        );
 
         UserGoal selectedGoal = UserGoal.of(
                 10L,
@@ -372,13 +445,18 @@ class LearningGoalServiceTest {
         given(goalMasterRepository.findAllByIsActiveTrue())
                 .willReturn(List.of(goal1, goal2, goal3));
 
-        given(userGoalRepository.findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE))
-                .willReturn(List.of(selectedGoal));
+        given(userGoalRepository.findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        )).willReturn(List.of(selectedGoal));
 
         List<GoalMaster> result = learningGoalService.getAvailableGoals(userId);
 
         verify(goalMasterRepository).findAllByIsActiveTrue();
-        verify(userGoalRepository).findAllByUser_UserIdAndStatus(userId, UserGoalStatus.ACTIVE);
+        verify(userGoalRepository).findByUserIdAndStatusWithGoalMaster(
+                userId,
+                UserGoalStatus.ACTIVE
+        );
 
         assertEquals(2, result.size());
         assertEquals(2L, result.get(0).getGoalMasterId());


### PR DESCRIPTION
## 작업내용
* 사용자 학습 목표 조회 시 GoalMaster 정보를 함께 조회하도록 수정
* 진행 중 목표 조회 API 500 오류 수정
* 완료된 목표 조회 API 조회 로직 수정
* 학습 목표 관련 테스트 코드 수정

## 변경사항
* UserGoalRepository에 JOIN FETCH 기반 조회 메서드 추가
* LearningGoalServiceImpl 목표 조회 로직 수정
* 진행 중/완료 목표 조회 시 GoalMaster 연관 데이터 함께 조회하도록 개선
* 기존 테스트 코드 mock 메서드명을 변경된 Repository 메서드 기준으로 수정

## 테스트 결과
* [x] LearningGoalServiceTest 통과
* [x] 진행 중 목표 조회 API 정상 동작 확인
* [x] 완료된 목표 조회 API 정상 동작 확인
* [x] 목표 추가 후 진행 중 목표 목록 정상 반영 확인
* [x] 목표 해제 후 목록 정상 반영 확인
<img width="317" height="92" alt="image" src="https://github.com/user-attachments/assets/a2e50fa8-6461-4780-8012-647dda1463f2" />


## 참고사항
* Lazy Loading으로 인해 DTO 변환 시 발생하던 오류를 JOIN FETCH 방식으로 해결했습니다.
* 사용자 학습 목표 페이지 프론트 연동 테스트 완료했습니다.


