### PR TITLE
feat(user): 유저 마이페이지 API 및 test코드 구현 완료

### DIFF
--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
 	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 	PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 	PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 전화번호입니다."),
+	DUPLICATE_PHONE_NUMBER(HttpStatus.CONFLICT, "이미 사용 중인 전화번호입니다."),
 	
 	//User 약관동의용
 	SERVICE_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "서비스 이용약관 동의는 필수입니다."),

--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
 	DUPLICATE_PHONE_NUMBER(HttpStatus.CONFLICT, "이미 사용 중인 전화번호입니다."),
 	INVALID_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),
 	SOCIAL_USER_CANNOT_CHANGE_PASSWORD(HttpStatus.BAD_REQUEST, "소셜 로그인 유저는 비밀번호를 변경할 수 없습니다."),
-	
+	ALREADY_DELETED_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 	
 	//User 약관동의용
 	SERVICE_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "서비스 이용약관 동의는 필수입니다."),

--- a/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
+++ b/src/main/java/kr/co/mapspring/global/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
 	PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 	PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 전화번호입니다."),
 	DUPLICATE_PHONE_NUMBER(HttpStatus.CONFLICT, "이미 사용 중인 전화번호입니다."),
+	INVALID_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),
+	SOCIAL_USER_CANNOT_CHANGE_PASSWORD(HttpStatus.BAD_REQUEST, "소셜 로그인 유저는 비밀번호를 변경할 수 없습니다."),
+	
 	
 	//User 약관동의용
 	SERVICE_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "서비스 이용약관 동의는 필수입니다."),

--- a/src/main/java/kr/co/mapspring/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/payment/service/impl/PaymentServiceImpl.java
@@ -1,13 +1,14 @@
 package kr.co.mapspring.payment.service.impl;
 
-import java.math.BigDecimal;
-
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
 
-import com.siot.IamportRestClient.IamportClient;
-import com.siot.IamportRestClient.response.IamportResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import kr.co.mapspring.global.exception.CustomException;
 import kr.co.mapspring.global.exception.ErrorCode;
 import kr.co.mapspring.payment.dto.PaymentDto;
@@ -36,13 +37,11 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Value("${portone.imp-secret}")
     private String impSecret;
-    
-    
-    
 
     @Override
     @Transactional
     public PaymentDto.ResponseVerify verifyAndSave(Long userId, PaymentDto.RequestVerify request) {
+
         // 1. 유저 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -52,37 +51,64 @@ public class PaymentServiceImpl implements PaymentService {
             throw new CustomException(ErrorCode.PAYMENT_ALREADY_EXISTS);
         }
 
-        // 3. 포트원 서버에 결제 검증 요청
-        // 프론트에서 받은 imp_uid로 포트원 서버에 실제 결제 정보를 조회해 위변조 방지
+        // 3. 포트원 REST API 직접 호출로 결제 검증
+        // iamport 라이브러리 대신 WebClient로 직접 호출 (라이브러리 버전 호환 문제 해결)
         try {
-            IamportClient iamportClient = new IamportClient(impKey, impSecret);
+            WebClient webClient = WebClient.create();
+            ObjectMapper mapper = new ObjectMapper();
 
-            // << 변경: 풀네임으로 사용해서 우리 Payment 엔티티와 충돌 방지
-            IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse =
-                    iamportClient.paymentByImpUid(request.getImpUid());
+            // 3-1. 포트원 액세스 토큰 발급
+            log.info("포트원 토큰 발급 시도...");
+            String tokenResponse = webClient.post()
+                    .uri("https://api.iamport.kr/users/getToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("{\"imp_key\":\"" + impKey + "\",\"imp_secret\":\"" + impSecret + "\"}")
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
 
-            com.siot.IamportRestClient.response.Payment iamportPayment =
-                    iamportResponse.getResponse();
+            JsonNode tokenNode = mapper.readTree(tokenResponse);
+            String accessToken = tokenNode.path("response").path("access_token").asText();
+            log.info("포트원 토큰 발급 성공");
+
+            // 3-2. imp_uid로 결제 정보 조회
+         // << 변경: 테스트 결제 조회용 URL
+            String paymentResponse = webClient.get()
+                    .uri("https://api.iamport.kr/payments/" + request.getImpUid())
+                    .header("Authorization", accessToken)
+                    .header("X-ImpTokenHeader", accessToken)  // << 추가
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            JsonNode paymentNode = mapper.readTree(paymentResponse);
+            JsonNode paymentData = paymentNode.path("response");
+
+            log.info("포트원 결제 상태: {}", paymentData.path("status").asText());
+            log.info("포트원 결제 금액: {}", paymentData.path("amount").asInt());
 
             // 4. 결제 금액 위변조 검증
-            BigDecimal requestAmount = new BigDecimal(request.getPaymentAmount());
-            if (iamportPayment.getAmount().compareTo(requestAmount) != 0) {
+            // 프론트에서 보낸 금액과 포트원 실제 결제 금액 비교
+            int paidAmount = paymentData.path("amount").asInt();
+            if (paidAmount != request.getPaymentAmount()) {
                 throw new CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
             }
 
             // 5. 결제 상태 확인 (paid 여야 성공)
-            if (!"paid".equals(iamportPayment.getStatus())) {
+            String status = paymentData.path("status").asText();
+            if (!"paid".equals(status)) {
                 throw new CustomException(ErrorCode.PAYMENT_NOT_PAID);
             }
 
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            log.error("포트원 결제 검증 실패: {}", e.getMessage());
+            log.error("포트원 결제 검증 실패 상세: {}", e.getMessage(), e);
             throw new CustomException(ErrorCode.PAYMENT_VERIFY_FAILED);
         }
 
         // 6. 기존 활성 구독 만료 처리
+        // 새로운 구독 전 기존 구독이 있으면 만료 처리
         subscriptionRepository
                 .findByPayment_UserAndPlanStatus(user, SubscriptionStatus.ACTIVE)
                 .ifPresent(Subscription::expire);

--- a/src/main/java/kr/co/mapspring/user/controller/UserController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.user.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -81,6 +82,21 @@ public class UserController implements UserControllerDocs{
         Long userId = jwtTokenProvider.getUserId(token);
         return ApiResponseDTO.success("내 정보 수정 성공", userService.updateMe(userId, updateRequest));
     }
+    
+    @Override
+    @DeleteMapping("/me")
+    public ApiResponseDTO<Void> deleteMe(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        String token = authHeader.substring(7);
+        Long userId = jwtTokenProvider.getUserId(token);
+        userService.deleteMe(userId);
+        return ApiResponseDTO.success("회원 탈퇴 성공", null);
+    }
+    
+    
     
     @Override
     @PatchMapping("/me/password")

--- a/src/main/java/kr/co/mapspring/user/controller/UserController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/UserController.java
@@ -82,5 +82,21 @@ public class UserController implements UserControllerDocs{
         return ApiResponseDTO.success("내 정보 수정 성공", userService.updateMe(userId, updateRequest));
     }
     
+    @Override
+    @PatchMapping("/me/password")
+    public ApiResponseDTO<Void> changePassword(
+            HttpServletRequest request,
+            @Valid @RequestBody UserDto.RequestChangePassword passwordRequest) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        String token = authHeader.substring(7);
+        Long userId = jwtTokenProvider.getUserId(token);
+        userService.changePassword(userId, passwordRequest);
+        return ApiResponseDTO.success("비밀번호 변경 성공", null);
+    }
+    
+    
     
 }

--- a/src/main/java/kr/co/mapspring/user/controller/UserController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/UserController.java
@@ -68,8 +68,19 @@ public class UserController implements UserControllerDocs{
         return ApiResponseDTO.success("프로필 입력 성공", response);
     }
     
-    
-    
+    @Override
+    @PatchMapping("/me")
+    public ApiResponseDTO<UserDto.ResponseUpdateMe> updateMe(
+            HttpServletRequest request,
+            @Valid @RequestBody UserDto.RequestUpdateMe updateRequest) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        String token = authHeader.substring(7);
+        Long userId = jwtTokenProvider.getUserId(token);
+        return ApiResponseDTO.success("내 정보 수정 성공", userService.updateMe(userId, updateRequest));
+    }
     
     
 }

--- a/src/main/java/kr/co/mapspring/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/UserControllerDocs.java
@@ -88,8 +88,8 @@ public interface UserControllerDocs {
             @Parameter(hidden = true)
             HttpServletRequest request
     );
-    
-    
+
+
     @Operation(
             summary = "소셜 유저 프로필 입력",
             description = """
@@ -199,12 +199,138 @@ public interface UserControllerDocs {
             )
             UserDto.RequestProfileSetup profileRequest
     );
-    
-    
-    
-    
-    
-    
-    
-    
+
+
+    @Operation(
+            summary = "내 정보 수정",
+            description = """
+                    현재 로그인한 유저의 정보를 수정합니다.
+                    이름, 생년월일, 주소, 전화번호를 수정할 수 있습니다.
+                    수정하지 않을 필드는 null로 보내면 됩니다.
+                    Authorization 헤더에 Bearer Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "내 정보 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "내 정보 수정 성공",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "내 정보 수정 성공",
+                                              "data": {
+                                                "userId": 1,
+                                                "email": "test@naver.com",
+                                                "name": "홍길동",
+                                                "birthDate": "2000-01-01",
+                                                "address": "서울시 강남구",
+                                                "phoneNumber": "01012345678"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 검증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "입력값 검증 실패",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "입력값 검증 실패",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "인증 실패",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 401,
+                                              "message": "인증이 필요합니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 유저",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "유저 없음",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 404,
+                                              "message": "존재하지 않는 이메일입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "전화번호 중복",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "전화번호 중복",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 409,
+                                              "message": "이미 사용 중인 전화번호입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponseDTO<UserDto.ResponseUpdateMe> updateMe(
+            @Parameter(hidden = true)
+            HttpServletRequest request,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "내 정보 수정 요청",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UserDto.RequestUpdateMe.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "name": "홍길동",
+                                              "birthDate": "2000-01-01",
+                                              "address": "서울시 강남구",
+                                              "phoneNumber": "01012345678"
+                                            }
+                                            """
+                            )
+                    )
+            )
+            UserDto.RequestUpdateMe updateRequest
+    );
 }

--- a/src/main/java/kr/co/mapspring/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/UserControllerDocs.java
@@ -333,4 +333,111 @@ public interface UserControllerDocs {
             )
             UserDto.RequestUpdateMe updateRequest
     );
+
+
+    @Operation(
+            summary = "비밀번호 변경",
+            description = """
+                    현재 비밀번호 확인 후 새 비밀번호로 변경합니다.
+                    소셜 로그인 유저는 비밀번호 변경이 불가합니다.
+                    Authorization 헤더에 Bearer Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 변경 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "비밀번호 변경 성공",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "비밀번호 변경 성공",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "새 비밀번호 불일치 또는 소셜 유저",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "새 비밀번호 불일치",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "현재 비밀번호 불일치",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "현재 비밀번호 불일치",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 401,
+                                              "message": "현재 비밀번호가 일치하지 않습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 유저",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "유저 없음",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 404,
+                                              "message": "존재하지 않는 이메일입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponseDTO<Void> changePassword(
+            @Parameter(hidden = true)
+            HttpServletRequest request,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "비밀번호 변경 요청",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UserDto.RequestChangePassword.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "currentPassword": "1234",
+                                              "newPassword": "Qwer1234!",
+                                              "newPasswordConfirm": "Qwer1234!"
+                                            }
+                                            """
+                            )
+                    )
+            )
+            UserDto.RequestChangePassword passwordRequest
+    );
 }

--- a/src/main/java/kr/co/mapspring/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/UserControllerDocs.java
@@ -430,14 +430,102 @@ public interface UserControllerDocs {
                             examples = @ExampleObject(
                                     value = """
                                             {
-                                              "currentPassword": "1234",
-                                              "newPassword": "Qwer1234!",
-                                              "newPasswordConfirm": "Qwer1234!"
+                                              "currentPassword": "currentPassword1!",
+                                              "newPassword": "newPassword1!",
+                                              "newPasswordConfirm": "newPassword1!"
                                             }
                                             """
                             )
                     )
             )
             UserDto.RequestChangePassword passwordRequest
+    );
+
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = """
+                    현재 로그인한 유저를 탈퇴 처리합니다.
+                    실제 삭제가 아닌 status를 DELETED로 변경합니다.
+                    Authorization 헤더에 Bearer Access Token이 필요합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "회원 탈퇴 성공",
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "회원 탈퇴 성공",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "이미 탈퇴한 회원",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "이미 탈퇴한 회원",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 400,
+                                              "message": "이미 탈퇴한 회원입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "인증 실패",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 401,
+                                              "message": "인증이 필요합니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 유저",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "유저 없음",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 404,
+                                              "message": "존재하지 않는 이메일입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ApiResponseDTO<Void> deleteMe(
+            @Parameter(hidden = true)
+            HttpServletRequest request
     );
 }

--- a/src/main/java/kr/co/mapspring/user/dto/UserDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/UserDto.java
@@ -159,7 +159,27 @@ public class UserDto {
     }
     
     
-    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "비밀번호 변경 요청 DTO")
+    public static class RequestChangePassword {
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        @Schema(description = "현재 비밀번호", example = "currentPassword1!")
+        private String currentPassword;
+
+        @NotBlank(message = "새 비밀번호를 입력해주세요.")
+        @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+            message = "비밀번호는 8~20자, 영문/숫자/특수문자를 포함해야 합니다."
+        )
+        @Schema(description = "새 비밀번호", example = "newPassword1!")
+        private String newPassword;
+
+        @NotBlank(message = "새 비밀번호 확인을 입력해주세요.")
+        @Schema(description = "새 비밀번호 확인", example = "newPassword1!")
+        private String newPasswordConfirm;
+    }
     
     
     

--- a/src/main/java/kr/co/mapspring/user/dto/UserDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/UserDto.java
@@ -52,6 +52,61 @@ public class UserDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(description = "내 정보 수정 요청 DTO")
+    public static class RequestUpdateMe {
+        @Schema(description = "이름", example = "홍길동")
+        private String name;
+
+        @Past(message = "미래 날짜는 생년월일로 사용할 수 없습니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        @Schema(description = "생년월일", example = "2000-01-01")
+        private LocalDate birthDate;
+
+        @Pattern(
+            regexp = "^[가-힣a-zA-Z0-9\\s\\-\\.\\,]+$",
+            message = "주소 형식이 올바르지 않습니다."
+        )
+        @Schema(description = "주소", example = "서울시 강남구")
+        private String address;
+
+        @Pattern(
+            regexp = "^01(?:0|1|[6-9])\\d{7,8}$",
+            message = "전화번호 형식이 올바르지 않습니다."
+        )
+        @Schema(description = "전화번호", example = "01012345678")
+        private String phoneNumber;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "내 정보 수정 응답 DTO")
+    public static class ResponseUpdateMe {
+        private Long userId;
+        private String email;
+        private String name;
+        private LocalDate birthDate;
+        private String address;
+        private String phoneNumber;
+
+        public static ResponseUpdateMe from(User user) {
+            return ResponseUpdateMe.builder()
+                    .userId(user.getUserId())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .birthDate(user.getBirthDate())
+                    .address(user.getAddress())
+                    .phoneNumber(user.getPhoneNumber())
+                    .build();
+        }
+    }
+    
+    
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(description = "소셜 유저 프로필 입력 요청 DTO")
     public static class RequestProfileSetup {
 

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -185,4 +185,9 @@ public class User {
         this.passwordHash = encodedPassword;
     }
     
+    // 회원 탈퇴
+    public void delete() {
+        this.status = UserStatus.DELETED;
+    }
+    
 }

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -172,7 +172,7 @@ public class User {
         this.phoneNumber = phoneNumber;
     }
     
- // 유저프로필 업데이트
+    // 유저프로필 업데이트
     public void updateProfile(String name, LocalDate birthDate, String address, String phoneNumber) {
         if (name != null && !name.isBlank()) this.name = name;
         if (birthDate != null) this.birthDate = birthDate;
@@ -180,6 +180,9 @@ public class User {
         if (phoneNumber != null && !phoneNumber.isBlank()) this.phoneNumber = phoneNumber;
     }
     
-    
+    // 비밀번호 변경
+    public void changePassword(String encodedPassword) {
+        this.passwordHash = encodedPassword;
+    }
     
 }

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -172,4 +172,14 @@ public class User {
         this.phoneNumber = phoneNumber;
     }
     
+ // 유저프로필 업데이트
+    public void updateProfile(String name, LocalDate birthDate, String address, String phoneNumber) {
+        if (name != null && !name.isBlank()) this.name = name;
+        if (birthDate != null) this.birthDate = birthDate;
+        if (address != null && !address.isBlank()) this.address = address;
+        if (phoneNumber != null && !phoneNumber.isBlank()) this.phoneNumber = phoneNumber;
+    }
+    
+    
+    
 }

--- a/src/main/java/kr/co/mapspring/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/mapspring/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     
     boolean existsByPhoneNumber(String phoneNumber);
+    
+    boolean existsByPhoneNumberAndUserIdNot(String phoneNumber, Long userId);
 }

--- a/src/main/java/kr/co/mapspring/user/service/UserService.java
+++ b/src/main/java/kr/co/mapspring/user/service/UserService.java
@@ -12,4 +12,6 @@ public interface UserService {
     UserDto.ResponseProfileSetup setupProfile(Long userId, UserDto.RequestProfileSetup request);
     
     UserDto.ResponseUpdateMe updateMe(Long userId, UserDto.RequestUpdateMe request);
+    
+    void changePassword(Long userId, UserDto.RequestChangePassword request);
 }

--- a/src/main/java/kr/co/mapspring/user/service/UserService.java
+++ b/src/main/java/kr/co/mapspring/user/service/UserService.java
@@ -9,6 +9,7 @@ public interface UserService {
      */
     UserDto.ResponseMe getMe(Long userId);
     
-    
     UserDto.ResponseProfileSetup setupProfile(Long userId, UserDto.RequestProfileSetup request);
+    
+    UserDto.ResponseUpdateMe updateMe(Long userId, UserDto.RequestUpdateMe request);
 }

--- a/src/main/java/kr/co/mapspring/user/service/UserService.java
+++ b/src/main/java/kr/co/mapspring/user/service/UserService.java
@@ -14,4 +14,6 @@ public interface UserService {
     UserDto.ResponseUpdateMe updateMe(Long userId, UserDto.RequestUpdateMe request);
     
     void changePassword(Long userId, UserDto.RequestChangePassword request);
+    
+    void deleteMe(Long userId);
 }

--- a/src/main/java/kr/co/mapspring/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/UserServiceImpl.java
@@ -8,6 +8,7 @@ import kr.co.mapspring.global.exception.CustomException;
 import kr.co.mapspring.global.exception.ErrorCode;
 import kr.co.mapspring.user.dto.UserDto;
 import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.enums.UserStatus;
 import kr.co.mapspring.user.repository.UserRepository;
 import kr.co.mapspring.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -108,7 +109,18 @@ public class UserServiceImpl implements UserService {
 
         user.changePassword(passwordEncoder.encode(request.getNewPassword()));
     }
-    
+	    @Override
+	    @Transactional
+	    public void deleteMe(Long userId) {
+	        User user = userRepository.findById(userId)
+	                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+	
+	        if (user.getStatus() == UserStatus.DELETED) {
+	            throw new CustomException(ErrorCode.ALREADY_DELETED_USER);
+	        }
+	
+	        user.delete();
+    }
     
     
 }

--- a/src/main/java/kr/co/mapspring/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/UserServiceImpl.java
@@ -57,4 +57,31 @@ public class UserServiceImpl implements UserService {
 
         return UserDto.ResponseProfileSetup.from(user);
     }    
+    
+    @Override
+    @Transactional
+    public UserDto.ResponseUpdateMe updateMe(Long userId, UserDto.RequestUpdateMe request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 전화번호 중복 체크 (변경하는 경우에만)
+        if (request.getPhoneNumber() != null && !request.getPhoneNumber().isBlank()) {
+            if (userRepository.existsByPhoneNumberAndUserIdNot(request.getPhoneNumber(), userId)) {
+                throw new CustomException(ErrorCode.DUPLICATE_PHONE_NUMBER);
+            }
+        }
+
+        user.updateProfile(
+                request.getName(),
+                request.getBirthDate(),
+                request.getAddress(),
+                request.getPhoneNumber()
+        );
+
+        return UserDto.ResponseUpdateMe.from(user);
+    }
+    
+    
+    
+    
 }

--- a/src/main/java/kr/co/mapspring/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/UserServiceImpl.java
@@ -1,5 +1,9 @@
 package kr.co.mapspring.user.service.impl;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.co.mapspring.global.exception.CustomException;
 import kr.co.mapspring.global.exception.ErrorCode;
 import kr.co.mapspring.user.dto.UserDto;
@@ -7,14 +11,14 @@ import kr.co.mapspring.user.entity.User;
 import kr.co.mapspring.user.repository.UserRepository;
 import kr.co.mapspring.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     @Transactional(readOnly = true)
@@ -81,6 +85,29 @@ public class UserServiceImpl implements UserService {
         return UserDto.ResponseUpdateMe.from(user);
     }
     
+    @Override
+    @Transactional
+    public void changePassword(Long userId, UserDto.RequestChangePassword request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 소셜 유저 체크 (passwordHash가 null이면 소셜 유저)
+        if (user.getPasswordHash() == null) {
+            throw new CustomException(ErrorCode.SOCIAL_USER_CANNOT_CHANGE_PASSWORD);
+        }
+
+        // 현재 비밀번호 확인
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPasswordHash())) {
+            throw new CustomException(ErrorCode.INVALID_CURRENT_PASSWORD);
+        }
+
+        // 새 비밀번호 확인
+        if (!request.getNewPassword().equals(request.getNewPasswordConfirm())) {
+            throw new CustomException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
+        }
+
+        user.changePassword(passwordEncoder.encode(request.getNewPassword()));
+    }
     
     
     

--- a/src/test/java/kr/co/mapspring/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/UserServiceTest.java
@@ -1,24 +1,28 @@
 package kr.co.mapspring.user.service;
 
-import kr.co.mapspring.global.exception.CustomException;
-import kr.co.mapspring.user.dto.UserDto;
-import kr.co.mapspring.user.entity.User;
-import kr.co.mapspring.user.repository.UserRepository;
-import kr.co.mapspring.user.service.impl.UserServiceImpl;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDate;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.user.dto.UserDto;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.repository.UserRepository;
+import kr.co.mapspring.user.service.impl.UserServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -28,6 +32,9 @@ class UserServiceTest {
 
     @InjectMocks
     private UserServiceImpl userService;
+    
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("유효한 userId면 내 정보 조회에 성공한다")
@@ -210,4 +217,113 @@ class UserServiceTest {
     }
     
     
+    @Test
+    @DisplayName("유효한 userId면 비밀번호 변경에 성공한다")
+    void changePasswordSuccess() {
+        // given
+        User user = createUser();
+        ReflectionTestUtils.setField(user, "passwordHash", "encodedPassword");
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+        given(passwordEncoder.matches("currentPassword1!", "encodedPassword"))
+                .willReturn(true);
+        given(passwordEncoder.encode("newPassword1!"))
+                .willReturn("newEncodedPassword");
+
+        UserDto.RequestChangePassword request = new UserDto.RequestChangePassword(
+                "currentPassword1!",
+                "newPassword1!",
+                "newPassword1!"
+        );
+
+        // when & then (void 메서드라 예외 없으면 성공)
+        assertThatCode(() -> userService.changePassword(1L, request))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("소셜 유저는 비밀번호 변경 시 예외가 발생한다")
+    void changePasswordFailWhenSocialUser() {
+        // given
+        User user = User.createOauthUser("test@gmail.com", "홍길동");
+        ReflectionTestUtils.setField(user, "userId", 1L);
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        UserDto.RequestChangePassword request = new UserDto.RequestChangePassword(
+                "currentPassword1!",
+                "newPassword1!",
+                "newPassword1!"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(1L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("소셜 로그인 유저는 비밀번호를 변경할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호가 틀리면 예외가 발생한다")
+    void changePasswordFailWhenWrongCurrentPassword() {
+        // given
+        User user = createUser();
+        ReflectionTestUtils.setField(user, "passwordHash", "encodedPassword");
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrongPassword!", "encodedPassword"))
+                .willReturn(false);
+
+        UserDto.RequestChangePassword request = new UserDto.RequestChangePassword(
+                "wrongPassword!",
+                "newPassword1!",
+                "newPassword1!"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(1L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("현재 비밀번호가 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("새 비밀번호와 확인이 다르면 예외가 발생한다")
+    void changePasswordFailWhenPasswordConfirmMismatch() {
+        // given
+        User user = createUser();
+        ReflectionTestUtils.setField(user, "passwordHash", "encodedPassword");
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+        given(passwordEncoder.matches("currentPassword1!", "encodedPassword"))
+                .willReturn(true);
+
+        UserDto.RequestChangePassword request = new UserDto.RequestChangePassword(
+                "currentPassword1!",
+                "newPassword1!",
+                "differentPassword1!"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(1L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 userId면 비밀번호 변경 시 예외가 발생한다")
+    void changePasswordFailWhenUserNotFound() {
+        // given
+        given(userRepository.findById(999L))
+                .willReturn(Optional.empty());
+
+        UserDto.RequestChangePassword request = new UserDto.RequestChangePassword(
+                "currentPassword1!",
+                "newPassword1!",
+                "newPassword1!"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(999L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("존재하지 않는 이메일입니다.");
+    }
 }

--- a/src/test/java/kr/co/mapspring/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/UserServiceTest.java
@@ -326,4 +326,46 @@ class UserServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasMessage("존재하지 않는 이메일입니다.");
     }
+    @Test
+    @DisplayName("유효한 userId면 회원 탈퇴에 성공한다")
+    void deleteMeSuccess() {
+        // given
+        User user = createUser();
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        // when & then
+        assertThatCode(() -> userService.deleteMe(1L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("이미 탈퇴한 유저면 예외가 발생한다")
+    void deleteMeFailWhenAlreadyDeleted() {
+        // given
+        User user = createUser();
+        user.delete();
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteMe(1L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 탈퇴한 회원입니다.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 userId면 회원 탈퇴 시 예외가 발생한다")
+    void deleteMeFailWhenUserNotFound() {
+        // given
+        given(userRepository.findById(999L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteMe(999L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("존재하지 않는 이메일입니다.");
+    }
+    
+    
 }

--- a/src/test/java/kr/co/mapspring/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/UserServiceTest.java
@@ -118,5 +118,96 @@ class UserServiceTest {
                 .hasMessage("존재하지 않는 이메일입니다.");
     }
     
+    @Test
+    @DisplayName("유효한 userId면 내 정보 수정에 성공한다")
+    void updateMeSuccess() {
+        // given
+        User user = createUser();
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+        given(userRepository.existsByPhoneNumberAndUserIdNot("01099998888", 1L))
+                .willReturn(false);
+
+        UserDto.RequestUpdateMe request = new UserDto.RequestUpdateMe(
+                "김철수",
+                LocalDate.of(1995, 5, 5),
+                "서울시 서초구",
+                "01099998888"
+        );
+
+        // when
+        UserDto.ResponseUpdateMe response = userService.updateMe(1L, request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getName()).isEqualTo("김철수");
+        assertThat(response.getBirthDate()).isEqualTo(LocalDate.of(1995, 5, 5));
+        assertThat(response.getAddress()).isEqualTo("서울시 서초구");
+        assertThat(response.getPhoneNumber()).isEqualTo("01099998888");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 userId면 내 정보 수정 시 예외가 발생한다")
+    void updateMeFailWhenUserNotFound() {
+        // given
+        given(userRepository.findById(999L))
+                .willReturn(Optional.empty());
+
+        UserDto.RequestUpdateMe request = new UserDto.RequestUpdateMe(
+                "김철수",
+                LocalDate.of(1995, 5, 5),
+                "서울시 서초구",
+                "01099998888"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateMe(999L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("존재하지 않는 이메일입니다.");
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 전화번호로 수정 시 예외가 발생한다")
+    void updateMeFailWhenDuplicatePhoneNumber() {
+        // given
+        User user = createUser();
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+        given(userRepository.existsByPhoneNumberAndUserIdNot("01099998888", 1L))
+                .willReturn(true);
+
+        UserDto.RequestUpdateMe request = new UserDto.RequestUpdateMe(
+                "김철수",
+                LocalDate.of(1995, 5, 5),
+                "서울시 서초구",
+                "01099998888"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateMe(1L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 사용 중인 전화번호입니다.");
+    }
+
+    @Test
+    @DisplayName("null 필드는 수정하지 않는다")
+    void updateMeWithNullFields() {
+        // given
+        User user = createUser();
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        UserDto.RequestUpdateMe request = new UserDto.RequestUpdateMe(
+                null, null, null, null
+        );
+
+        // when
+        UserDto.ResponseUpdateMe response = userService.updateMe(1L, request);
+
+        // then
+        assertThat(response.getName()).isEqualTo("홍길동");
+        assertThat(response.getAddress()).isEqualTo("서울시 강남구");
+    }
+    
     
 }


### PR DESCRIPTION
## 작업내용
유저 마이페이지 API 구현 (내 정보 수정, 비밀번호 변경, 회원 탈퇴)

## 변경사항
- User.java - updateProfile, changePassword, delete, updateStatus 메서드 추가
- UserDto.java - RequestUpdateMe, ResponseUpdateMe, RequestChangePassword DTO 추가
- UserService.java - updateMe, changePassword, deleteMe 메서드 추가
- UserServiceImpl.java - 위 메서드 구현
- UserController.java - PATCH /api/users/me, PATCH /api/users/me/password, DELETE /api/users/me 엔드포인트 추가
- UserControllerDocs.java - Swagger 문서 추가
- UserRepository.java - existsByPhoneNumberAndUserIdNot 메서드 추가



## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="637" height="462" alt="image" src="https://github.com/user-attachments/assets/67ae63fd-4021-452e-be8f-527515c78db7" />
테스트 코드 정삭 작동
<img width="1153" height="711" alt="image" src="https://github.com/user-attachments/assets/0dcfed61-5fbc-413c-ac57-c5412d085e14" />
회원정보 수정 정상 작동
<img width="1223" height="747" alt="image" src="https://github.com/user-attachments/assets/2d50230f-c577-41df-8b1f-3bae1cdc1bca" />
회원 탈퇴 정상 작동
<img width="1272" height="558" alt="image" src="https://github.com/user-attachments/assets/38b8774b-b2c7-4458-9bf5-f8e2ee1e7040" />
비밀번호 변경 정삭 작동

## 참고사항
- 비밀번호 변경 시 소셜 유저 여부 체크 (passwordHash null 확인)
- 전화번호 수정 시 본인 제외 중복 체크
- 회원 탈퇴는 실제 삭제가 아닌 status DELETED로 변경하는 soft delete 방식

