### PR TITLE
feat(user): 관리자 회원 관리 API 구현 (회원 목록 조회, 회원 상세 조회, 회원 상태 변경)

### DIFF
--- a/src/main/java/kr/co/mapspring/user/controller/AdminUserController.java
+++ b/src/main/java/kr/co/mapspring/user/controller/AdminUserController.java
@@ -1,0 +1,51 @@
+package kr.co.mapspring.user.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.user.controller.docs.AdminUserControllerDocs;
+import kr.co.mapspring.user.dto.AdminUserDto;
+import kr.co.mapspring.user.service.AdminUserService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController implements AdminUserControllerDocs {
+
+    private final AdminUserService adminUserService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponseDTO<List<AdminUserDto.ResponseList>>> getUserList(
+            @RequestParam(name = "keyword", required = false) String keyword) {
+        return ResponseEntity.ok(ApiResponseDTO.success("회원 목록 조회 완료",
+                adminUserService.getUserList(keyword)));
+    }
+
+    @Override
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponseDTO<AdminUserDto.ResponseDetail>> getUserDetail(
+            @PathVariable("userId") Long userId) {
+        return ResponseEntity.ok(ApiResponseDTO.success("회원 상세 조회 완료",
+                adminUserService.getUserDetail(userId)));
+    }
+
+    @Override
+    @PatchMapping("/{userId}/status")
+    public ResponseEntity<ApiResponseDTO<Void>> updateUserStatus(
+            @PathVariable("userId") Long userId,
+            @RequestBody AdminUserDto.RequestUpdateStatus request) {
+        adminUserService.updateUserStatus(userId, request);
+        return ResponseEntity.ok(ApiResponseDTO.success("회원 상태 변경 완료"));
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/controller/docs/AdminUserControllerDocs.java
+++ b/src/main/java/kr/co/mapspring/user/controller/docs/AdminUserControllerDocs.java
@@ -1,0 +1,150 @@
+package kr.co.mapspring.user.controller.docs;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.mapspring.global.dto.ApiResponseDTO;
+import kr.co.mapspring.user.dto.AdminUserDto;
+
+@Tag(name = "Admin-User", description = "관리자 회원 관리 API")
+public interface AdminUserControllerDocs {
+
+    @Operation(summary = "회원 목록 조회", description = "전체 회원 목록을 조회합니다. keyword로 이름/이메일 검색 가능합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "회원 목록 조회 완료",
+                                              "data": [
+                                                {
+                                                  "userId": 1,
+                                                  "email": "test@naver.com",
+                                                  "name": "홍길동",
+                                                  "phoneNumber": "01012345678",
+                                                  "role": "USER",
+                                                  "status": "ACTIVE",
+                                                  "createdAt": "2024-01-01T00:00:00"
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<ApiResponseDTO<List<AdminUserDto.ResponseList>>> getUserList(
+            @RequestParam(name = "keyword", required = false) String keyword
+    );
+
+    @Operation(summary = "회원 상세 조회", description = "특정 회원의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 상세 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "회원 상세 조회 완료",
+                                              "data": {
+                                                "userId": 1,
+                                                "email": "test@naver.com",
+                                                "name": "홍길동",
+                                                "birthDate": "2000-01-01",
+                                                "address": "서울시 강남구",
+                                                "phoneNumber": "01012345678",
+                                                "role": "USER",
+                                                "status": "ACTIVE",
+                                                "lastLoginAt": "2024-01-01T00:00:00",
+                                                "createdAt": "2024-01-01T00:00:00",
+                                                "updatedAt": "2024-01-01T00:00:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 유저",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 404,
+                                              "message": "존재하지 않는 이메일입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<ApiResponseDTO<AdminUserDto.ResponseDetail>> getUserDetail(
+            @PathVariable("userId") Long userId
+    );
+
+    @Operation(summary = "회원 상태 변경", description = "특정 회원의 상태를 변경합니다. (ACTIVE/INACTIVE/SUSPENDED/DELETED)")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 상태 변경 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "status": 200,
+                                              "message": "회원 상태 변경 완료",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 유저",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "status": 404,
+                                              "message": "존재하지 않는 이메일입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<ApiResponseDTO<Void>> updateUserStatus(
+            @PathVariable("userId") Long userId,
+            @RequestBody AdminUserDto.RequestUpdateStatus request
+    );
+}

--- a/src/main/java/kr/co/mapspring/user/dto/AdminUserDto.java
+++ b/src/main/java/kr/co/mapspring/user/dto/AdminUserDto.java
@@ -1,0 +1,87 @@
+package kr.co.mapspring.user.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.enums.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AdminUserDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "회원 목록 응답 DTO")
+    public static class ResponseList {
+        private Long userId;
+        private String email;
+        private String name;
+        private String phoneNumber;
+        private String role;
+        private String status;
+        private LocalDateTime createdAt;
+
+        public static ResponseList from(User user) {
+            return ResponseList.builder()
+                    .userId(user.getUserId())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .phoneNumber(user.getPhoneNumber())
+                    .role(user.getRole().name())
+                    .status(user.getStatus().name())
+                    .createdAt(user.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "회원 상세 응답 DTO")
+    public static class ResponseDetail {
+        private Long userId;
+        private String email;
+        private String name;
+        private LocalDate birthDate;
+        private String address;
+        private String phoneNumber;
+        private String role;
+        private String status;
+        private LocalDateTime lastLoginAt;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static ResponseDetail from(User user) {
+            return ResponseDetail.builder()
+                    .userId(user.getUserId())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .birthDate(user.getBirthDate())
+                    .address(user.getAddress())
+                    .phoneNumber(user.getPhoneNumber())
+                    .role(user.getRole().name())
+                    .status(user.getStatus().name())
+                    .lastLoginAt(user.getLastLoginAt())
+                    .createdAt(user.getCreatedAt())
+                    .updatedAt(user.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "회원 상태 변경 요청 DTO")
+    public static class RequestUpdateStatus {
+        @Schema(description = "변경할 상태", example = "SUSPENDED")
+        private UserStatus status;
+    }
+}

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -190,4 +190,9 @@ public class User {
         this.status = UserStatus.DELETED;
     }
     
+    // 회원 상태
+    public void updateStatus(UserStatus status) {
+        this.status = status;
+    }
+    
 }

--- a/src/main/java/kr/co/mapspring/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/mapspring/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package kr.co.mapspring.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByPhoneNumber(String phoneNumber);
     
     boolean existsByPhoneNumberAndUserIdNot(String phoneNumber, Long userId);
+    
+    List<User> findByNameContainingOrEmailContaining(String name, String email);
 }

--- a/src/main/java/kr/co/mapspring/user/service/AdminUserService.java
+++ b/src/main/java/kr/co/mapspring/user/service/AdminUserService.java
@@ -1,0 +1,10 @@
+package kr.co.mapspring.user.service;
+
+import java.util.List;
+import kr.co.mapspring.user.dto.AdminUserDto;
+
+public interface AdminUserService {
+    List<AdminUserDto.ResponseList> getUserList(String keyword);
+    AdminUserDto.ResponseDetail getUserDetail(Long userId);
+    void updateUserStatus(Long userId, AdminUserDto.RequestUpdateStatus request);
+}

--- a/src/main/java/kr/co/mapspring/user/service/impl/AdminUserServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/user/service/impl/AdminUserServiceImpl.java
@@ -1,0 +1,52 @@
+package kr.co.mapspring.user.service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.global.exception.ErrorCode;
+import kr.co.mapspring.user.dto.AdminUserDto;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.repository.UserRepository;
+import kr.co.mapspring.user.service.AdminUserService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserServiceImpl implements AdminUserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AdminUserDto.ResponseList> getUserList(String keyword) {
+        List<User> users;
+        if (keyword != null && !keyword.isBlank()) {
+            users = userRepository.findByNameContainingOrEmailContaining(keyword, keyword);
+        } else {
+            users = userRepository.findAll();
+        }
+        return users.stream()
+                .map(AdminUserDto.ResponseList::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminUserDto.ResponseDetail getUserDetail(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return AdminUserDto.ResponseDetail.from(user);
+    }
+
+    @Override
+    @Transactional
+    public void updateUserStatus(Long userId, AdminUserDto.RequestUpdateStatus request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.updateStatus(request.getStatus());
+    }
+}

--- a/src/test/java/kr/co/mapspring/user/service/AdminUserServiceTest.java
+++ b/src/test/java/kr/co/mapspring/user/service/AdminUserServiceTest.java
@@ -1,0 +1,160 @@
+package kr.co.mapspring.user.service;
+
+import kr.co.mapspring.global.exception.CustomException;
+import kr.co.mapspring.user.dto.AdminUserDto;
+import kr.co.mapspring.user.entity.User;
+import kr.co.mapspring.user.enums.UserStatus;
+import kr.co.mapspring.user.repository.UserRepository;
+import kr.co.mapspring.user.service.impl.AdminUserServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AdminUserServiceImpl adminUserService;
+
+    @Test
+    @DisplayName("키워드 없이 전체 회원 목록 조회에 성공한다")
+    void getUserListSuccessWithoutKeyword() {
+        // given
+        User user = createUser();
+        given(userRepository.findAll())
+                .willReturn(List.of(user));
+
+        // when
+        List<AdminUserDto.ResponseList> result = adminUserService.getUserList(null);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getEmail()).isEqualTo("test@naver.com");
+        assertThat(result.get(0).getName()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("키워드로 회원 목록 검색에 성공한다")
+    void getUserListSuccessWithKeyword() {
+        // given
+        User user = createUser();
+        given(userRepository.findByNameContainingOrEmailContaining("홍길동", "홍길동"))
+                .willReturn(List.of(user));
+
+        // when
+        List<AdminUserDto.ResponseList> result = adminUserService.getUserList("홍길동");
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("키워드 검색 결과가 없으면 빈 리스트를 반환한다")
+    void getUserListEmptyWithKeyword() {
+        // given
+        given(userRepository.findByNameContainingOrEmailContaining("없는사람", "없는사람"))
+                .willReturn(List.of());
+
+        // when
+        List<AdminUserDto.ResponseList> result = adminUserService.getUserList("없는사람");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("유효한 userId면 회원 상세 조회에 성공한다")
+    void getUserDetailSuccess() {
+        // given
+        User user = createUser();
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        // when
+        AdminUserDto.ResponseDetail result = adminUserService.getUserDetail(1L);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getUserId()).isEqualTo(1L);
+        assertThat(result.getEmail()).isEqualTo("test@naver.com");
+        assertThat(result.getName()).isEqualTo("홍길동");
+        assertThat(result.getStatus()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 userId면 회원 상세 조회 시 예외가 발생한다")
+    void getUserDetailFailWhenUserNotFound() {
+        // given
+        given(userRepository.findById(999L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminUserService.getUserDetail(999L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("존재하지 않는 이메일입니다.");
+    }
+
+    @Test
+    @DisplayName("유효한 userId면 회원 상태 변경에 성공한다")
+    void updateUserStatusSuccess() {
+        // given
+        User user = createUser();
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        AdminUserDto.RequestUpdateStatus request =
+                new AdminUserDto.RequestUpdateStatus(UserStatus.SUSPENDED);
+
+        // when & then
+        assertThatCode(() -> adminUserService.updateUserStatus(1L, request))
+                .doesNotThrowAnyException();
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.SUSPENDED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 userId면 상태 변경 시 예외가 발생한다")
+    void updateUserStatusFailWhenUserNotFound() {
+        // given
+        given(userRepository.findById(999L))
+                .willReturn(Optional.empty());
+
+        AdminUserDto.RequestUpdateStatus request =
+                new AdminUserDto.RequestUpdateStatus(UserStatus.SUSPENDED);
+
+        // when & then
+        assertThatThrownBy(() -> adminUserService.updateUserStatus(999L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("존재하지 않는 이메일입니다.");
+    }
+
+    private User createUser() {
+        User user = User.create(
+                "test@naver.com",
+                "홍길동",
+                LocalDate.of(2000, 1, 1),
+                "서울시 강남구",
+                "01012345678",
+                "encodedPassword"
+        );
+        ReflectionTestUtils.setField(user, "userId", 1L);
+        return user;
+    }
+}


### PR DESCRIPTION
## 작업내용
- 관리자 회원 관리 API 구현 (회원 목록 조회, 회원 상세 조회, 회원 상태 변경)


## 변경사항
- AdminUserDto.java - ResponseList, ResponseDetail, RequestUpdateStatus DTO 추가 
- AdminUserService.java - getUserList, getUserDetail, updateUserStatus 메서드 정의 
- AdminUserServiceImpl.java - 위 메서드 구현
- AdminUserController.java - GET /api/admin/users, GET /api/admin/users/{userId}, 


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
<img width="817" height="738" alt="image" src="https://github.com/user-attachments/assets/5038b9ff-49fe-49ee-94d9-2b66026dc758" />
회원 상태 변경
<img width="984" height="626" alt="image" src="https://github.com/user-attachments/assets/8801388b-3877-487c-a9a4-34b487e1c710" />
전체 회원 조회
<img width="1031" height="508" alt="image" src="https://github.com/user-attachments/assets/9d0f5923-16e1-4790-85d2-d89a17816ae4" />
특정 회원 상세 조회

## 참고사항
- 회원 목록 조회 시 keyword로 이름/이메일 검색 가능
- 회원 상태 변경 가능 값: ACTIVE, INACTIVE, SUSPENDED, DELETED
