### PR TITLE
fix(admin-social): 신고 처리 시 사용자 상태 변경 및 이름 표시 개선

### DIFF
--- a/src/main/java/kr/co/mapspring/social/dto/AdminSocialDto.java
+++ b/src/main/java/kr/co/mapspring/social/dto/AdminSocialDto.java
@@ -26,8 +26,14 @@ public class AdminSocialDto {
         @Schema(description = "신고자 ID", example = "1")
         private Long reporterId;
 
+        @Schema(description = "신고자 이름", example = "신고자")
+        private String reporterName;
+
         @Schema(description = "신고 대상 사용자 ID", example = "2")
         private Long reportedUserId;
+
+        @Schema(description = "신고 대상 사용자 이름", example = "신고대상")
+        private String reportedUserName;
 
         @Schema(description = "신고 사유", example = "욕설")
         private String reason;
@@ -48,7 +54,9 @@ public class AdminSocialDto {
             return ResponseReport.builder()
                     .reportId(userReport.getReportId())
                     .reporterId(userReport.getReporter().getUserId())
+                    .reporterName(userReport.getReporter().getName())
                     .reportedUserId(userReport.getReportedUser().getUserId())
+                    .reportedUserName(userReport.getReportedUser().getName())
                     .reason(userReport.getReason())
                     .status(userReport.getStatus())
                     .createdAt(userReport.getCreatedAt())
@@ -83,8 +91,14 @@ public class AdminSocialDto {
         @Schema(description = "요청 보낸 사용자 ID", example = "1")
         private Long requesterId;
 
+        @Schema(description = "요청 보낸 사용자 이름", example = "신고자")
+        private String requesterName;
+
         @Schema(description = "요청 받은 사용자 ID", example = "2")
         private Long addresseeId;
+
+        @Schema(description = "요청 받은 사용자 이름", example = "신고대상")
+        private String addresseeName;
 
         @Schema(description = "친구 상태", example = "BLOCKED")
         private FriendshipStatus status;
@@ -99,7 +113,9 @@ public class AdminSocialDto {
             return ResponseFriendshipHistory.builder()
                     .friendshipId(friendship.getFriendshipId())
                     .requesterId(friendship.getRequester().getUserId())
+                    .requesterName(friendship.getRequester().getName())
                     .addresseeId(friendship.getAddressee().getUserId())
+                    .addresseeName(friendship.getAddressee().getName())
                     .status(friendship.getStatus())
                     .requestedAt(friendship.getRequestedAt())
                     .respondedAt(friendship.getRespondedAt())

--- a/src/main/java/kr/co/mapspring/social/service/impl/AdminSocialServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/social/service/impl/AdminSocialServiceImpl.java
@@ -47,6 +47,7 @@ public class AdminSocialServiceImpl implements AdminSocialService {
 
         if (request.getStatus() == ReportStatus.RESOLVED) {
             userReport.resolve(request.getAdminMemo());
+            userReport.getReportedUser().deactivate();
             return;
         }
 

--- a/src/test/java/kr/co/mapspring/social/service/AdminSocialServiceTest.java
+++ b/src/test/java/kr/co/mapspring/social/service/AdminSocialServiceTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -129,8 +130,8 @@ public class AdminSocialServiceTest {
     }
 
     @Test
-    @DisplayName("관리자는 신고를 처리 완료 상태로 변경한다")
-    void 관리자는_신고를_처리_완료_상태로_변경한다() {
+    @DisplayName("관리자는 신고를 처리 완료 상태로 변경하고 신고당한 사용자를 비활성화한다")
+    void 관리자는_신고를_처리_완료_상태로_변경하고_신고당한_사용자를_비활성화한다() {
 
         Long reportId = 1L;
         String adminMemo = "신고 내용 확인 후 처리 완료";
@@ -158,6 +159,7 @@ public class AdminSocialServiceTest {
         adminSocialService.updateReportStatus(reportId, request);
 
         verify(userReportRepository).findById(reportId);
+        verify(reportedUser).deactivate();
 
         assertEquals(ReportStatus.RESOLVED, report.getStatus());
         assertEquals(adminMemo, report.getAdminMemo());
@@ -194,6 +196,7 @@ public class AdminSocialServiceTest {
         adminSocialService.updateReportStatus(reportId, request);
 
         verify(userReportRepository).findById(reportId);
+        verify(reportedUser, never()).deactivate();
 
         assertEquals(ReportStatus.REJECTED, report.getStatus());
         assertEquals(adminMemo, report.getAdminMemo());


### PR DESCRIPTION
## 작업내용
- 관리자 신고 처리 완료 시 신고 대상 사용자 상태 변경 로직 추가
- 신고/친구 관계 응답 DTO에 사용자 이름 필드 추가
- 관리자 신고 처리 테스트 코드 보강

## 변경사항
- 신고 상태가 `RESOLVED`로 변경되면 신고 대상 사용자 `status`를 `INACTIVE`로 변경
- `AdminSocialDto.ResponseReport`
  - `reporterName`
  - `reportedUserName`
  필드 추가
- `AdminSocialDto.ResponseFriendshipHistory`
  - `requesterName`
  - `addresseeName`
  필드 추가
- 신고 처리 테스트에 `deactivate()` 호출 검증 추가
- 신고 반려(`REJECTED`) 시 사용자 상태가 변경되지 않는 테스트 추가

## 테스트 결과
- [x] 신고 상태 `RESOLVED` 변경 시 사용자 상태 `INACTIVE` 변경 확인
- [x] 신고 상태 `REJECTED` 변경 시 사용자 상태 유지 확인
- [x] 신고 목록/상세 응답에 사용자 이름 정상 포함
- [x] 차단/거절 이력 응답에 사용자 이름 정상 포함
- [x] 관리자 신고 상태 변경 기능 정상 동작

## 참고사항
- 사용자 상태 변경은 기존 `User.deactivate()` 메서드를 사용했습니다.