### PR TITLE
fix(ranking): JPQL named parameter 매핑 오류 수정

### DIFF
--- a/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
+++ b/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
@@ -3,6 +3,7 @@ package kr.co.mapspring.ranking.repository;
 import kr.co.mapspring.learning.entity.StudyScore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,21 +25,21 @@ public interface RankingRepository extends JpaRepository<StudyScore, Long> {
            GROUP BY ss.studyLog.user.userId, ss.studyLog.user.name
            ORDER BY SUM(ss.totalScore) DESC
            """)
-    List<Object[]> findFriendRanking(List<Long> friendIds);
+    List<Object[]> findFriendRanking(@Param("friendIds") List<Long> friendIds);
 
     @Query("""
            SELECT COALESCE(MAX(ss.totalScore), 0)
            FROM StudyScore ss
            WHERE ss.studyLog.user.userId IN :friendIds
            """)
-    Long findFriendBestScore(List<Long> friendIds);
+    Long findFriendBestScore(@Param("friendIds") List<Long> friendIds);
 
     @Query("""
            SELECT COALESCE(AVG(ss.totalScore), 0)
            FROM StudyScore ss
            WHERE ss.studyLog.user.userId IN :friendIds
            """)
-    Double findFriendAverageScore(List<Long> friendIds);
+    Double findFriendAverageScore(@Param("friendIds") List<Long> friendIds);
 
     @Query("""
        SELECT ss.studyLog.user.userId, ss.studyLog.user.name, SUM(ss.totalScore)
@@ -47,5 +48,5 @@ public interface RankingRepository extends JpaRepository<StudyScore, Long> {
        GROUP BY ss.studyLog.user.userId, ss.studyLog.user.name
        ORDER BY SUM(ss.totalScore) DESC
        """)
-    List<Object[]> findWeeklyRanking(LocalDateTime startDateTime);
+    List<Object[]> findWeeklyRanking(@Param("startDateTime") LocalDateTime startDateTime);
 }

--- a/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
+++ b/src/main/java/kr/co/mapspring/ranking/repository/RankingRepository.java
@@ -37,7 +37,7 @@ public interface RankingRepository extends JpaRepository<StudyScore, Long> {
     @Query("""
            SELECT COALESCE(AVG(ss.totalScore), 0)
            FROM StudyScore ss
-           WHERE ss.studyLog.user.userId IN :friendIds
+           WHERE ss.studyLog.user.userId IN :friendIds 
            """)
     Double findFriendAverageScore(@Param("friendIds") List<Long> friendIds);
 


### PR DESCRIPTION
## 작업내용
- 커뮤니티 랭킹 페이지 진입 시 발생하던 서버 오류 수정
- 랭킹 Repository의 JPQL named parameter 매핑 누락 수정

## 변경사항
- `RankingRepository`의 `@Query` 파라미터에 `@Param` 추가
- 친구 랭킹 조회 `friendIds` 파라미터 매핑 수정
- 친구 최고 점수 조회 `friendIds` 파라미터 매핑 수정
- 친구 평균 점수 조회 `friendIds` 파라미터 매핑 수정
- 주간 랭킹 조회 `startDateTime` 파라미터 매핑 수정

## 테스트 결과
- [x] `/api/rankings/weekly` 정상 응답 확인
- [x] 친구 랭킹 조회 정상 동작 확인
- [x] 커뮤니티 랭킹 페이지 진입 시 서버 오류 미발생 확인
- [x] 백엔드 콘솔에서 `InvalidDataAccessApiUsageException` 미발생 확인

## 참고사항
- 기존 오류는 JPQL named parameter에 `@Param`이 누락되어 발생했습니다.