### PR TITLE
fix(admin-social): 신고 상태 변경 시 대상 사용자 상태 동기화

### DIFF
--- a/src/main/java/kr/co/mapspring/social/service/impl/AdminSocialServiceImpl.java
+++ b/src/main/java/kr/co/mapspring/social/service/impl/AdminSocialServiceImpl.java
@@ -53,6 +53,7 @@ public class AdminSocialServiceImpl implements AdminSocialService {
 
         if (request.getStatus() == ReportStatus.REJECTED) {
             userReport.reject(request.getAdminMemo());
+            userReport.getReportedUser().activate();
         }
     }
 

--- a/src/main/java/kr/co/mapspring/user/entity/User.java
+++ b/src/main/java/kr/co/mapspring/user/entity/User.java
@@ -164,6 +164,11 @@ public class User {
     public void deactivate() {
         this.status = UserStatus.INACTIVE;
     }
+
+    // 신고 반려 또는 제재 해제 시 사용자 계정을 다시 활성화
+    public void activate() {
+        this.status = UserStatus.ACTIVE;
+    }
     
     // 소셜 유저 프로필 저장
     public void setupProfile(LocalDate birthDate, String address, String phoneNumber) {


### PR DESCRIPTION
## 작업내용
- 관리자 신고 상태 변경 시 신고 대상 사용자 상태 동기화 로직 추가
- 신고 처리 완료/반려 상태에 따른 사용자 상태 변경 처리

## 변경사항
- 신고 상태가 `RESOLVED`로 변경되면 신고 대상 사용자 상태를 `INACTIVE`로 변경
- 신고 상태가 `REJECTED`로 변경되면 신고 대상 사용자 상태를 `ACTIVE`로 복구
- `User` 엔티티에 활성화 처리 메서드 추가
- 신고자(reporter)가 아닌 신고 대상자(reportedUser) 기준으로 상태 변경 처리

## 테스트 결과
- [x] 신고 처리 완료 시 reported_user_id 사용자의 status가 INACTIVE로 변경됨
- [x] 신고 반려 시 reported_user_id 사용자의 status가 ACTIVE로 복구됨
- [x] 신고자(reporter_id) 상태는 변경되지 않음
- [x] 관리자 신고 상태 변경 기능 정상 동작 확인
- [x] DB에서 user.status 변경 확인

[ 관리자가 신고 처리 완료 후 계정 비활성화 된 상태 ]
<img width="1396" height="936" alt="신고 처리 완료된 상태" src="https://github.com/user-attachments/assets/114d1842-73c3-4456-92f1-75124bb6f8fb" />

[ 관리자가 신고 처리 반려 ]
<img width="1397" height="935" alt="신고처리반려중" src="https://github.com/user-attachments/assets/287f9fc7-aabf-4c40-9d9d-f84f9a5ee080" />

[ 관리자가 신고 처리 반려 후 계정이 다시 활성화된 상태 ]
<img width="1392" height="938" alt="반려후로그인성공" src="https://github.com/user-attachments/assets/227f77c3-fa1e-4b82-9753-6759e49283b7" />


## 참고사항
- 상태 변경 대상은 `reporter_id`가 아니라 `reported_user_id`입니다.