### PR TITLE
fix(favorite): 즐겨찾기 조회 파라미터 바인딩 오류 수정

### DIFF
--- a/src/main/java/kr/co/mapspring/favorite/controller/FavoritePlaceController.java
+++ b/src/main/java/kr/co/mapspring/favorite/controller/FavoritePlaceController.java
@@ -39,7 +39,7 @@ public class FavoritePlaceController implements FavoritePlaceControllerDocs {
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponseDTO<List<FavoritePlaceDto.ResponseFavoritePlace>>> getFavoritePlaces(@RequestParam Long userId) {
+    public ResponseEntity<ApiResponseDTO<List<FavoritePlaceDto.ResponseFavoritePlace>>> getFavoritePlaces(@RequestParam("userId") Long userId) {
 
         List<FavoritePlaceDto.ResponseFavoritePlace> result =
                 favoritePlaceService.getFavoritePlaces(userId)


### PR DESCRIPTION
## 작업내용
- 즐겨찾기 장소/시나리오 조회 API 500 오류 수정
- RequestParam 파라미터 이름 명시 처리


## 변경사항
- FavoritePlaceController 수정
- FavoriteScenarioController 수정
- @RequestParam("userId") 명시 추가


## 오류 원인
- Spring에서 Long 타입 RequestParam 이름을 reflection으로 읽지 못해
  파라미터 바인딩에 실패하면서 500 에러가 발생하던 문제 수정


## 테스트 결과_캡쳐 이미지 (.jpg/.png)
- [x] 장소 즐겨찾기 조회 정상 동작 확인
- [x] 시나리오 즐겨찾기 조회 정상 동작 확인
- [x] 500 에러 미발생 확인
<img width="437" height="260" alt="즐겨찾기500에러해결" src="https://github.com/user-attachments/assets/e465fda3-c2da-457d-854d-17e76507e5af" />


## 참고사항
- 현재 즐겨찾기 조회 API 수정만 반영된 상태입니다.
- 즐겨찾기 추가 버튼 UI는 추후 프론트에서 생성 예정입니다.

