### PR TITLE
fix(user-friend): 친구 사용자 정보 및 LazyInitializationException 해결

### DIFF
--- a/src/main/java/kr/co/mapspring/social/controller/FriendshipController.java
+++ b/src/main/java/kr/co/mapspring/social/controller/FriendshipController.java
@@ -27,114 +27,169 @@ public class FriendshipController implements FriendshipControllerDocs {
 
     @Override
     @PostMapping("/requests")
-    public ResponseEntity<ApiResponseDTO<Void>> sendFriendRequest(@RequestParam("loginUserId") Long loginUserId,
-                                                                  @RequestBody FriendshipDto.RequestSendFriendRequest request) {
+    public ResponseEntity<ApiResponseDTO<Void>> sendFriendRequest(
+            @RequestParam("loginUserId") Long loginUserId,
+            @RequestBody FriendshipDto.RequestSendFriendRequest request
+    ) {
         friendshipService.sendFriendRequest(
                 loginUserId,
                 request.getAddresseeId()
         );
 
-        return ResponseEntity.ok(ApiResponseDTO.success("친구 요청을 보냈습니다.", null));
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("친구 요청을 보냈습니다.", null)
+        );
     }
 
     @Override
     @PostMapping("/requests/email")
-    public ResponseEntity<ApiResponseDTO<Void>> sendFriendRequestByEmail(@RequestParam("loginUserId") Long loginUserId,
-                                                                         @RequestBody FriendshipDto.RequestSendFriendRequestByEmail request) {
+    public ResponseEntity<ApiResponseDTO<Void>> sendFriendRequestByEmail(
+            @RequestParam("loginUserId") Long loginUserId,
+            @RequestBody FriendshipDto.RequestSendFriendRequestByEmail request
+    ) {
 
         friendshipService.sendFriendRequestByEmail(
                 loginUserId,
                 request.getEmail()
         );
 
-        return ResponseEntity.ok(ApiResponseDTO.success("이메일로 친구 요청을 보냈습니다.", null));
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("이메일로 친구 요청을 보냈습니다.", null)
+        );
     }
 
     @Override
     @PatchMapping("/requests/{friendshipId}/accept")
-    public ResponseEntity<ApiResponseDTO<Void>> acceptFriendRequest(@PathVariable("friendshipId") Long friendshipId,
-                                                                    @RequestParam("loginUserId") Long loginUserId) {
+    public ResponseEntity<ApiResponseDTO<Void>> acceptFriendRequest(
+            @PathVariable("friendshipId") Long friendshipId,
+            @RequestParam("loginUserId") Long loginUserId
+    ) {
         friendshipService.acceptFriendRequest(
                 friendshipId,
                 loginUserId
         );
 
-        return ResponseEntity.ok(ApiResponseDTO.success("친구 요청을 수락했습니다.", null));
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("친구 요청을 수락했습니다.", null)
+        );
     }
 
     @Override
     @PatchMapping("/requests/{friendshipId}/reject")
-    public ResponseEntity<ApiResponseDTO<Void>> rejectFriendRequest(@PathVariable("friendshipId") Long friendshipId,
-                                                                    @RequestParam("loginUserId") Long loginUserId) {
+    public ResponseEntity<ApiResponseDTO<Void>> rejectFriendRequest(
+            @PathVariable("friendshipId") Long friendshipId,
+            @RequestParam("loginUserId") Long loginUserId
+    ) {
         friendshipService.rejectFriendRequest(
                 friendshipId,
                 loginUserId
         );
 
-        return ResponseEntity.ok(ApiResponseDTO.success("친구 요청을 거절했습니다.", null));
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("친구 요청을 거절했습니다.", null)
+        );
     }
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getFriends(@RequestParam("userId") Long userId) {
-        List<FriendshipDto.ResponseFriend> result = friendshipService.getFriends(userId).stream()
-                .map(FriendshipDto.ResponseFriend::from)
-                .toList();
+    public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getFriends(
+            @RequestParam("userId") Long userId
+    ) {
 
-        return ResponseEntity.ok(ApiResponseDTO.success("친구 목록 조회 성공", result));
+        // 수정 전 코드
+        List<FriendshipDto.ResponseFriend> result =
+                friendshipService.getFriends(userId).stream()
+                        .map(FriendshipDto.ResponseFriend::from)
+                        .toList();
+
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("친구 목록 조회 성공", result)
+        );
     }
 
     @Override
     @DeleteMapping("/{friendshipId}")
-    public ResponseEntity<ApiResponseDTO<Void>> deleteFriend(@PathVariable("friendshipId") Long friendshipId,
-                                                             @RequestParam("loginUserId") Long loginUserId) {
+    public ResponseEntity<ApiResponseDTO<Void>> deleteFriend(
+            @PathVariable("friendshipId") Long friendshipId,
+            @RequestParam("loginUserId") Long loginUserId
+    ) {
+
         friendshipService.deleteFriend(
                 friendshipId,
                 loginUserId
         );
 
-        return ResponseEntity.ok(ApiResponseDTO.success("친구를 삭제했습니다.", null));
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("친구를 삭제했습니다.", null)
+        );
     }
 
     @Override
     @GetMapping("/requests/received")
-    public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getReceivedRequests(@RequestParam("userId") Long userId) {
-        List<FriendshipDto.ResponseFriend> result = friendshipService.getReceivedRequests(userId).stream()
-                .map(FriendshipDto.ResponseFriend::from)
-                .toList();
+    public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getReceivedRequests(
+            @RequestParam("userId") Long userId
+    ) {
 
-        return ResponseEntity.ok(ApiResponseDTO.success("받은 친구 요청 조회 성공", result));
+        // 수정 전 코드
+        List<FriendshipDto.ResponseFriend> result =
+                friendshipService.getReceivedRequests(userId).stream()
+                        .map(FriendshipDto.ResponseFriend::from)
+                        .toList();
+
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("받은 친구 요청 조회 성공", result)
+        );
     }
 
     @Override
     @GetMapping("/requests/sent")
-    public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getSentRequests(@RequestParam("userId") Long userId) {
-        List<FriendshipDto.ResponseFriend> result = friendshipService.getSentRequests(userId).stream()
-                .map(FriendshipDto.ResponseFriend::from)
-                .toList();
+    public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getSentRequests(
+            @RequestParam("userId") Long userId
+    ) {
 
-        return ResponseEntity.ok(ApiResponseDTO.success("보낸 친구 요청 조회 성공", result));
+        // 수정 전 코드
+        List<FriendshipDto.ResponseFriend> result =
+                friendshipService.getSentRequests(userId).stream()
+                        .map(FriendshipDto.ResponseFriend::from)
+                        .toList();
+
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("보낸 친구 요청 조회 성공", result)
+        );
     }
 
     @Override
     @PatchMapping("/{friendshipId}/block")
-    public ResponseEntity<ApiResponseDTO<Void>> blockFriend(@PathVariable("friendshipId") Long friendshipId,
-                                                            @RequestParam("loginUserId") Long loginUserId) {
+    public ResponseEntity<ApiResponseDTO<Void>> blockFriend(
+            @PathVariable("friendshipId") Long friendshipId,
+            @RequestParam("loginUserId") Long loginUserId
+    ) {
+
         friendshipService.blockFriend(
                 friendshipId,
-                loginUserId);
+                loginUserId
+        );
 
-        return ResponseEntity.ok(ApiResponseDTO.success("친구를 차단했습니다.", null));
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("친구를 차단했습니다.", null)
+        );
     }
 
     @Override
     @GetMapping("/history")
-    public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getFriendshipHistory(@RequestParam("userId") Long userId) {
-        List<FriendshipDto.ResponseFriend> result = friendshipService.getFriendshipHistory(userId).stream()
-                .map(FriendshipDto.ResponseFriend::from)
-                .toList();
+    public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseFriend>>> getFriendshipHistory(
+            @RequestParam("userId") Long userId
+    ) {
 
-        return ResponseEntity.ok(ApiResponseDTO.success("차단 및 거절 이력 조회 성공", result));
+        // 수정 전 코드
+        List<FriendshipDto.ResponseFriend> result =
+                friendshipService.getFriendshipHistory(userId).stream()
+                        .map(FriendshipDto.ResponseFriend::from)
+                        .toList();
+
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("차단 및 거절 이력 조회 성공", result)
+        );
     }
 
     @Override
@@ -142,10 +197,14 @@ public class FriendshipController implements FriendshipControllerDocs {
     public ResponseEntity<ApiResponseDTO<List<FriendshipDto.ResponseRecommendedFriend>>> getRecommendedFriends(
             @RequestParam("userId") Long userId
     ) {
-        List<FriendshipDto.ResponseRecommendedFriend> result = friendshipService.getRecommendedFriends(userId).stream()
-                .map(FriendshipDto.ResponseRecommendedFriend::from)
-                .toList();
 
-        return ResponseEntity.ok(ApiResponseDTO.success("추천 친구 조회 성공", result));
+        List<FriendshipDto.ResponseRecommendedFriend> result =
+                friendshipService.getRecommendedFriends(userId).stream()
+                        .map(FriendshipDto.ResponseRecommendedFriend::from)
+                        .toList();
+
+        return ResponseEntity.ok(
+                ApiResponseDTO.success("추천 친구 조회 성공", result)
+        );
     }
 }

--- a/src/main/java/kr/co/mapspring/social/dto/FriendshipDto.java
+++ b/src/main/java/kr/co/mapspring/social/dto/FriendshipDto.java
@@ -39,20 +39,38 @@ public class FriendshipDto {
         @Schema(description = "요청 보낸 사용자 ID", example = "1")
         private Long requesterId;
 
+        @Schema(description = "요청 보낸 사용자 이름", example = "이민수")
+        private String requesterName;
+
+        @Schema(description = "요청 보낸 사용자 이메일", example = "user1@test.com")
+        private String requesterEmail;
+
         @Schema(description = "요청 받은 사용자 ID", example = "2")
         private Long addresseeId;
+
+        @Schema(description = "요청 받은 사용자 이름", example = "김가연")
+        private String addresseeName;
+
+        @Schema(description = "요청 받은 사용자 이메일", example = "user2@test.com")
+        private String addresseeEmail;
 
         @Schema(description = "친구 상태 (PENDING, ACCEPTED, REJECTED)", example = "ACCEPTED")
         private FriendshipStatus status;
 
         public static ResponseFriend from(Friendship friendship) {
+            User requester = friendship.getRequester();
+            User addressee = friendship.getAddressee();
+
             return ResponseFriend.builder()
                     .friendshipId(friendship.getFriendshipId())
                     .requesterId(friendship.getRequester().getUserId())
+                    .requesterName(requester.getName())
+                    .requesterEmail(requester.getEmail())
                     .addresseeId(friendship.getAddressee().getUserId())
+                    .addresseeName(addressee.getName())
+                    .addresseeEmail(addressee.getEmail())
                     .status(friendship.getStatus())
-                    .build();
-        }
+                    .build(); }
     }
 
     @Getter

--- a/src/main/java/kr/co/mapspring/social/repository/FriendshipRepository.java
+++ b/src/main/java/kr/co/mapspring/social/repository/FriendshipRepository.java
@@ -25,6 +25,8 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query("""
            SELECT f
            FROM Friendship f
+           JOIN FETCH f.requester
+           JOIN FETCH f.addressee
            WHERE (f.requester.userId = :userId OR f.addressee.userId = :userId)
              AND f.status = :status
            """)
@@ -40,6 +42,8 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query("""
            SELECT f
            FROM Friendship f
+           JOIN FETCH f.requester
+           JOIN FETCH f.addressee
            WHERE f.addressee.userId = :userId
              AND f.status = :status
            """)
@@ -55,6 +59,8 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query("""
            SELECT f
            FROM Friendship f
+           JOIN FETCH f.requester
+           JOIN FETCH f.addressee
            WHERE f.requester.userId = :userId
              AND f.status = :status
            """)
@@ -70,6 +76,8 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query("""
            SELECT f
            FROM Friendship f
+           JOIN FETCH f.requester
+           JOIN FETCH f.addressee
            WHERE (f.requester.userId = :userId OR f.addressee.userId = :userId)
              AND f.status IN (kr.co.mapspring.social.enums.FriendshipStatus.REJECTED,
                               kr.co.mapspring.social.enums.FriendshipStatus.BLOCKED)


### PR DESCRIPTION
## 작업내용

* 친구 목록/요청 조회 시 사용자 이름 및 이메일 정보 반환 추가
* Friendship DTO에 requester/addressee 사용자 정보 필드 추가
* LazyInitializationException 발생 문제 해결
* 친구 목록에서 fallback 사용자명(`사용자 #id`) 표시 문제 수정

## 변경사항

* FriendshipDto.ResponseFriend 필드 추가

  * requesterName
  * requesterEmail
  * addresseeName
  * addresseeEmail

* FriendshipRepository 조회 쿼리에 fetch join 추가

  * requester / addressee 엔티티 즉시 조회 처리

* 프론트 sessionStorage 캐시 초기화 후 정상 동작 확인

## 테스트 결과

* [x] 친구 목록 이름 정상 표시
* [x] 받은 친구 요청 이름 정상 표시
* [x] 차단/거절 이력 이름 정상 표시
* [x] LazyInitializationException 해결 확인

